### PR TITLE
Support github URLs with non-standard filenames

### DIFF
--- a/src/opam_cmd.ml
+++ b/src/opam_cmd.ml
@@ -68,6 +68,7 @@ let tag_from_archive archive =
       match path with
       | [u; r; "releases"; "download"; v; archive] -> Some v
       | [u; r; "archive"; archive] -> Some (strip_ext archive)
+      | [u; r; "archive"; tag; _] -> Some tag
       | _ -> if Uri.scheme uri = Some "git+https" then None else parse_err () )
     | Some "ocaml.janestreet.com" -> (
       match path with


### PR DESCRIPTION
Github download URLs are normally of the form:

    https://github.com/proj/repo/archive/tag.extension

but it also supports URLs of the form:

    https://github.com/proj/repo/archive/tag/filname.extension

which allows better control of the final filename. This patch
adds support for the latter.

Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>