### PR TITLE
Move vendored sources from ocaml_modules to duniverse

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ DESCRIPTION
 
        It works by analysing opam package metadata and calculating a set of
        git tags that can be cloned into the local repository into an
-       ocaml_modules subdirectory. Once the external code has been pulled
+       duniverse subdirectory. Once the external code has been pulled
        into the repository, a single dune build command is sufficient to
        build the whole project in a standalone fashion, without opam being
        required. This is a particularly convenient way of publishing CLI

--- a/doc/spec.md
+++ b/doc/spec.md
@@ -209,9 +209,6 @@ dune overrides.  Instead, it just adds `dune-universe/opam-repository` to its
 remote list before calculating the packages, and that is sufficient to pull in
 the overridden packages.
 
-TODO: what should the name of the vendor directory be? We currently use
-`ocaml_modules` since `vendor/` is used by some packages (such as ocamlformat).
-
 The automatic git invocations have also been problematic.  For phase 1,
 we could remove all automatic `git commit` and simply fetch the archives
 for the user to manually git add/remove/commit.

--- a/src/config.ml
+++ b/src/config.ml
@@ -77,7 +77,7 @@ let opam_lockfile = Fpath.(duniverse_dir / "opam.sxp")
 
 let duniverse_lockfile = Fpath.(duniverse_dir / "dune.sxp")
 
-let vendor_dir = Fpath.v "ocaml_modules"
+let vendor_dir = Fpath.v "duniverse"
 
 let duniverse_log = Fpath.v ".duniverse-log"
 

--- a/src/duniverse.ml
+++ b/src/duniverse.ml
@@ -148,7 +148,7 @@ let dune_lock_cmd =
     ; `P
         "This command takes the standalone opam package list calculated using \
          $(i,duniverse opam) and converts it into a set of git tags that can \
-         be put into the $(b,ocaml_modules/) subdirectory and act as vendored \
+         be put into the $(b,duniverse/) subdirectory and act as vendored \
          copies of the source code."
     ; `P
         "The opam packages are sorted by their Git remotes and deduplicated \
@@ -180,7 +180,7 @@ let dune_fetch_cmd =
     ; `P
         "This command reads the Git metadata calculated with $(i,duniverse \
          lock) and fetches them from their respective Git remotes and stores \
-         them in the $(b,ocaml_modules/) directory in the repository." ]
+         them in the $(b,duniverse/) directory in the repository." ]
   in
   ( (let open Term in
     term_result
@@ -220,7 +220,7 @@ let default_cmd =
     ; `P
         "It works by analysing opam package metadata and calculating a set of \
          git tags that can be cloned into the local repository into an \
-         $(i,ocaml_modules) subdirectory.  Once the external code has been \
+         $(i,duniverse) subdirectory.  Once the external code has been \
          pulled into the repository, a single $(b,dune build) command is \
          sufficient to build the whole project in a standalone fashion, \
          without opam being required.  This is a particularly convenient way \


### PR DESCRIPTION
The name `ocaml_modules` might be slightly confusing as we're not actually vendoring ocaml modules but entire dune projects.