### PR TITLE
Use an opam repo to resolve dune overlays

### DIFF
--- a/src/config.ml
+++ b/src/config.ml
@@ -29,47 +29,7 @@ let base_packages =
   ; "ocaml-base-compiler"
   ; "ocaml-variants" ]
 
-let duniverse_forks =
-  [ ("git+http://erratique.ch/repos/uutf.git", "uutf")
-  ; ("git+http://erratique.ch/repos/astring.git", "astring")
-  ; ("git+http://erratique.ch/repos/asetmap.git", "asetmap")
-  ; ("git+http://erratique.ch/repos/logs.git", "logs")
-  ; ("git+http://erratique.ch/repos/react.git", "react")
-  ; ("git+http://erratique.ch/repos/xmlm.git", "xmlm")
-  ; ("git+http://erratique.ch/repos/webbrowser.git", "webbrowser")
-  ; ("git+http://erratique.ch/repos/uuidm.git", "uuidm")
-  ; ("git+http://erratique.ch/repos/uutf.git", "uutf")
-  ; ("git+http://erratique.ch/repos/mtime.git", "mtime")
-  ; ("git+http://erratique.ch/repos/ptime.git", "ptime")
-  ; ("git+http://erratique.ch/repos/fmt.git", "fmt")
-  ; ("git+http://erratique.ch/repos/rresult.git", "rresult")
-  ; ("git+http://erratique.ch/repos/jsonm.git", "jsonm")
-  ; ("git+http://erratique.ch/repos/fpath.git", "fpath")
-  ; ("git+http://erratique.ch/repos/bos.git", "bos")
-  ; ("git+http://erratique.ch/repos/topkg.git", "topkg")
-  ; ("git+http://erratique.ch/repos/cmdliner.git", "cmdliner")
-  ; ("git+https://github.com/backtracking/ocaml-hashcons.git", "ocaml-hashcons")
-  ; ("git+https://github.com/backtracking/ocamlgraph.git", "ocamlgraph")
-  ; ("git+https://gitlab.camlcity.org/gerd/lib-findlib.git", "lib-findlib")
-  ; ("git+https://gforge.inria.fr/git/dose/dose.git", "dose3")
-  ; ("git+https://github.com/ocaml/opam-file-format", "opam-file-format")
-  ; ("git+https://scm.gforge.inria.fr/anonscm/git/cudf/cudf.git", "cudf")
-  ; ("git+https://github.com/ocaml/opam-depext.git#2.0", "opam-depext")
-  ; ("git+https://github.com/ocaml/opam.git", "opam")
-  ; ("git+https://github.com/superbobry/ocaml-textwrap.git", "ocaml-textwrap")
-  ; ("git://github.com/ygrek/ocaml-extlib.git", "ocaml-extlib")
-  ; ("git+https://github.com/mirage/mirage-xen.git", "mirage-xen")
-  ; ("git+https://github.com/mirage/mirage-entropy.git", "mirage-entropy")
-  ; ("git+https://github.com/pqwy/lru.git", "lru")
-  ; ("git+https://github.com/pqwy/psq.git", "psq")
-  ; ("git+https://github.com/ocsigen/reactiveData.git", "reactiveData")
-  ; ("git+https://github.com/mirleft/ocaml-asn1-combinators.git", "ocaml-asn1-combinators")
-  ; ("git+https://github.com/mirleft/ocaml-nocrypto.git", "ocaml-nocrypto")
-  ; ("git+https://github.com/mirleft/ocaml-tls.git", "ocaml-tls")
-  ; ("git+https://github.com/inhabitedtype/ocaml-dispatch.git", "ocaml-dispatch")
-  ; ("git+https://github.com/OCamlPro/ocplib-endian.git", "ocplib-endian") ]
-
-let duniverse_branch f = Fmt.strf "duniverse-%s" f
+let duniverse_overlays_repo = "git://github.com/dune-universe/opam-overlays.git"
 
 let duniverse_dir = Fpath.v ".duniverse"
 

--- a/src/dune_cmd.ml
+++ b/src/dune_cmd.ml
@@ -39,15 +39,6 @@ let dune_repo_of_opam ?(verify_refs = true) opam =
           Exec.git_default_branch ~remote:upstream ()
           >>= fun ref -> Ok {Dune.dir; upstream; ref}
       | Some ref -> Ok {Dune.dir; upstream; ref} )
-  | `Duniverse_fork repo ->
-      let upstream = Fmt.strf "git://github.com/dune-universe/%s.git" repo in
-      let ref =
-        match opam.Opam.tag with
-        | None -> "duniverse-master"
-        | Some t -> Config.duniverse_branch t
-      in
-      Logs.debug (fun l -> l "Duniverse fork: %s %s %s" dir upstream ref) ;
-      Ok {Dune.dir; upstream; ref}
   | x -> R.error_msg (Fmt.strf "TODO cannot handle %a" Opam.pp_entry opam)
 
 let dedup_git_remotes dunes =

--- a/src/exec.ml
+++ b/src/exec.ml
@@ -270,6 +270,13 @@ let init_local_opam_switch ~opam_switch ~repo ~remotes () =
           in
           OS.Cmd.(run ~err:err_null cmd) )
         remotes
+      >>= fun () ->
+      let cmd =
+        Cmd.(
+          v "opam" % "repository" %% switch_path repo % "add"
+          % "dune-overlays" % Config.duniverse_overlays_repo)
+      in
+      OS.Cmd.(run ~err:err_null cmd)
 
 let add_opam_dev_pin ~repo {Opam.pin; url; tag} =
   let targ =

--- a/src/types.ml
+++ b/src/types.ml
@@ -21,8 +21,6 @@ let pp_sexp fn ppf v = Fmt.pf ppf "%s" (Sexplib.Sexp.to_string_hum (fn v))
 module Opam = struct
   type repo =
     [ `Github of string * string
-    | `Duniverse_fork of string
-      (** [name] which is [https://github.com/dune-universe/name] *)
     | `Git of string
     | `Unknown of string
     | `Virtual


### PR DESCRIPTION
Use an opam repository to resolve dune overlay packages, instead of hardcoding the list in the source code.

The repo is here: https://github.com/dune-universe/opam-overlays

The repository is added to the local switch with the name `dune-overlays`, adding potential name collision.

This adds a regression: If there is no dune overlay for the lastest version of a package, the upstream version will be selected.
It can be fixed by checking if a dunified older version exists in the "package does not depend on dune" branch.