### PR TITLE
Fix CI script

### DIFF
--- a/.docker.sh
+++ b/.docker.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-DISTRO=${DISTRO:-alpine-3.7}
+DISTRO=${DISTRO:-alpine-3.9}
 
 set -ex
 # TODO opam2 depext
 case $DISTRO in
-alpine-*) sudo apk add m4 ;;
-debian-*) sudo apt update; sudo apt -y install m4 pkg-config ;;
-ubuntu-*) sudo apt update; sudo apt -y install m4 pkg-config ;;
+alpine*) sudo apk add m4 ;;
+debian*) sudo apt update; sudo apt -y install m4 pkg-config ;;
+ubuntu*) sudo apt update; sudo apt -y install m4 pkg-config ;;
 esac
 
 sudo chown -R opam /home/opam/src

--- a/.docker.sh
+++ b/.docker.sh
@@ -11,6 +11,8 @@ esac
 
 sudo chown -R opam /home/opam/src
 cd /home/opam/src
-opam install -y dune 
+opam pin add --no-action duniverse .
+opam update
+opam install --deps-only -t duniverse
 cd /home/opam/src
 make

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ script:
   - docker run -e DISTRO=${DISTRO} -v `pwd`:/home/opam/src ocaml/opam2:${DISTRO} /home/opam/src/.docker.sh
 env:
   matrix:
-  - DISTRO="debian-9"
-  - DISTRO="alpine-3.7"
+  - DISTRO="debian-stable"
+  - DISTRO="alpine"
   - DISTRO="ubuntu-16.04"
-  - DISTRO="ubuntu-18.04"
+  - DISTRO="ubuntu"


### PR DESCRIPTION
This is just a quick-fix, I'm not sure what the future of `duniverse` CI should be.

I first thought about using the regular `.travis-docker.sh`, which would work but I seem to recall a mention of `duniverse` being a standalone tool with vendored dependencies, in which case updating the custom CI script seems better!