### PR TITLE
Faster duniverse opam fetch using one single command.

### DIFF
--- a/lib/exec.ml
+++ b/lib/exec.ml
@@ -137,14 +137,12 @@ let opam_switch_create_empty ~root () =
   run_and_log cmd
 
 let run_opam_show ~root ~fields ~packages =
-  let fields_str = String.concat ~sep:"," fields
-  in
-  let packages_str = List.map Types.Opam.string_of_package packages
-  in
+  let fields_str = String.concat ~sep:"," fields in
+  let packages_str = List.map Types.Opam.string_of_package packages in
   let cmd =
     let open Cmd in
-    opam_cmd ~root "show" %"--color=never" % "--normalise"
-    % "-f" % fields_str %% (of_list packages_str)
+    opam_cmd ~root "show" % "--color=never" % "--normalise" % "-f" % fields_str
+    %% of_list packages_str
   in
   run_and_log_l cmd
 

--- a/lib/exec.ml
+++ b/lib/exec.ml
@@ -137,8 +137,6 @@ let opam_switch_create_empty ~root () =
   run_and_log cmd
 
 let run_opam_show ~root ~fields ~packages =
-  let fields = List.map (fun s -> s^":") fields in
-  let fields = "name"::fields in
   let fields_str = String.concat ~sep:"," fields
   in
   let packages_str = List.map Types.Opam.string_of_package packages

--- a/lib/exec.mli
+++ b/lib/exec.mli
@@ -56,12 +56,12 @@ val run_opam_package_deps : root:Fpath.t -> string list -> (string list, [> Rres
 (** [run_opam_packages_deps ~root packages] returns a list of versioned constrained packages that
     resolves the transitive dependencies of [packages]. *)
 
-module Opam_show_result : sig
-  type t
-
-  val make : root: Fpath.t -> string list -> Types.Opam.package list -> (t, [> Rresult.R.msg ]) result
-  val get  : package: string -> field: string -> t -> OpamParserTypes.value option
-end
+(** [run_opam_show ~root ~fields ~packages] runs opam show to get [fields] for each package in [packages].*)
+val run_opam_show :
+  root:Fpath.t ->
+  fields:string list ->
+  packages:Types.Opam.package list ->
+  (string list, [> Rresult.R.msg ]) result
 
 (** [init_local_opam_switch ~opam_switch ~root ~remotes ()] creates a fresh opam state and switch
     with compiler [compiler] using [root] as OPAMROOT and adds the [remotes] opam repositories

--- a/lib/exec.mli
+++ b/lib/exec.mli
@@ -56,12 +56,12 @@ val run_opam_package_deps : root:Fpath.t -> string list -> (string list, [> Rres
 (** [run_opam_packages_deps ~root packages] returns a list of versioned constrained packages that
     resolves the transitive dependencies of [packages]. *)
 
-(** [run_opam_show ~root ~fields ~packages] runs opam show to get [fields] for each package in [packages].*)
 val run_opam_show :
   root:Fpath.t ->
   fields:string list ->
   packages:Types.Opam.package list ->
   (string list, [> Rresult.R.msg ]) result
+(** [run_opam_show ~root ~fields ~packages] runs opam show to get [fields] for each package in [packages].*)
 
 val init_opam_and_remotes :
   root:Fpath.t -> remotes:Types.Opam.Remote.t list -> unit -> (unit, [> Rresult.R.msg ]) result

--- a/lib/exec.mli
+++ b/lib/exec.mli
@@ -56,11 +56,12 @@ val run_opam_package_deps : root:Fpath.t -> string list -> (string list, [> Rres
 (** [run_opam_packages_deps ~root packages] returns a list of versioned constrained packages that
     resolves the transitive dependencies of [packages]. *)
 
-val get_opam_fields :
-  root: Fpath.t ->
-  string list ->
-  Types.Opam.package list ->
-  (OpamParserTypes.value Types.StrMap.t, [> Rresult.R.msg ]) result
+module Opam_show_result : sig
+  type t
+
+  val make : root: Fpath.t -> string list -> Types.Opam.package list -> (t, [> Rresult.R.msg ]) result
+  val get  : package: string -> field: string -> t -> OpamParserTypes.value option
+end
 
 (** [init_local_opam_switch ~opam_switch ~root ~remotes ()] creates a fresh opam state and switch
     with compiler [compiler] using [root] as OPAMROOT and adds the [remotes] opam repositories

--- a/lib/exec.mli
+++ b/lib/exec.mli
@@ -52,21 +52,19 @@ val git_merge :
 (** [git_merge ~args ~repo branch] merges [from] into [repo]'s current active branch with the extra
     arguments [args]. *)
 
-val get_opam_depends : root:Fpath.t -> string -> (string list, [> Rresult.R.msg ]) result
-(** [get_opam_depends ~root package] returns the list of version constrained packages [package]
-    depends on using [root] as OPAMROOT. *)
-
-val get_opam_dev_repo : root:Fpath.t -> string -> (string, [> Rresult.R.msg ]) result
-(** [get_opam_dev_repo ~root package] returns the dev-repo for [package], using [root] as
-    OPAMROOT. *)
-
-val get_opam_archive_url : root:Fpath.t -> string -> (string option, [> Rresult.R.msg ]) result
-(** [get_opam_archive_url ~root package] returns the url.src for [package] or [None] if it isn't
-    specified, using [root] as OPAMROOT. *)
-
 val run_opam_package_deps : root:Fpath.t -> string list -> (string list, [> Rresult.R.msg ]) result
 (** [run_opam_packages_deps ~root packages] returns a list of versioned constrained packages that
     resolves the transitive dependencies of [packages]. *)
+
+val get_opam_fields :
+  root: Fpath.t ->
+  string list ->
+  Types.Opam.package list ->
+  (OpamParserTypes.value Types.StrMap.t, [> Rresult.R.msg ]) result
+
+(** [init_local_opam_switch ~opam_switch ~root ~remotes ()] creates a fresh opam state and switch
+    with compiler [compiler] using [root] as OPAMROOT and adds the [remotes] opam repositories
+    to it. *)
 
 val init_opam_and_remotes :
   root:Fpath.t -> remotes:Types.Opam.Remote.t list -> unit -> (unit, [> Rresult.R.msg ]) result

--- a/lib/exec.mli
+++ b/lib/exec.mli
@@ -63,13 +63,9 @@ val run_opam_show :
   packages:Types.Opam.package list ->
   (string list, [> Rresult.R.msg ]) result
 
-(** [init_local_opam_switch ~opam_switch ~root ~remotes ()] creates a fresh opam state and switch
-    with compiler [compiler] using [root] as OPAMROOT and adds the [remotes] opam repositories
-    to it. *)
-
 val init_opam_and_remotes :
   root:Fpath.t -> remotes:Types.Opam.Remote.t list -> unit -> (unit, [> Rresult.R.msg ]) result
-(** [init_local_opam_switch ~root ~remotes ()] creates a fresh opam state with a single
+(** [init_opam_and_remotes ~root ~remotes ()] creates a fresh opam state with a single
     switch using [root] as OPAMROOT and adds the [remotes] opam repositories to it. *)
 
 val add_opam_dev_pin : root:Fpath.t -> Types.Opam.pin -> (unit, [> Rresult.R.msg ]) result

--- a/lib/opam_cmd.ml
+++ b/lib/opam_cmd.ml
@@ -171,18 +171,18 @@ let parse_opam_depends ~package v =
 
 let get_opam_info ~root ~pins packages =
   let fields = ["dev-repo"; "url.src"; "depends"] in
-  Exec.get_opam_fields ~root fields packages
+  Exec.Opam_show_result.make ~root fields packages
    >>= fun data ->
   let packages = List.map
     (fun pkg ->
       let name = pkg.name in
-      let archive_url_line = Types.StrMap.find_opt (name^".url.src") data in
+      let archive_url_line = Exec.Opam_show_result.get ~package:name ~field:"url.src" data in
       let archive = parse_archive_url ~package:name archive_url_line
       in
-      let dev_repo_line = Types.StrMap.find_opt (name^".dev-repo") data in
+      let dev_repo_line = Exec.Opam_show_result.get ~package:name ~field:"dev-repo" data in
       let dev_repo = parse_dev_repo ~package:name dev_repo_line
       in
-      let depends_line = Types.StrMap.find_opt (name^".depends") data in
+      let depends_line = Exec.Opam_show_result.get ~package:name ~field:"depends" data in
       let depends = parse_opam_depends ~package:name depends_line
       in
       dev_repo >>= fun dev_repo ->

--- a/lib/opam_cmd.ml
+++ b/lib/opam_cmd.ml
@@ -164,8 +164,10 @@ let parse_opam_depends ~package v =
   | Some (Ok (List (_, vs))) ->
       let ss =
         List.fold_left
-          (fun acc -> function String (_, v) -> v :: acc
-            | Option (_, String (_, v), _) -> v :: acc | _ -> acc )
+          (fun acc ->
+            function
+            | Option (_, String (_, v), _) | String (_, v) -> v :: acc
+            | _ -> acc )
           [] vs
       in
       Logs.debug (fun l ->
@@ -181,7 +183,7 @@ let parse_opam_depends ~package v =
 
 
 let get_opam_info ~root ~pins packages =
-  let fields = ["dev-repo"; "url.src"; "depends"] in
+  let fields = ["name"; "dev-repo:"; "url.src:"; "depends:"] in
   Exec.run_opam_show ~root ~packages ~fields
   >>= fun lines ->
   Opam_show_result.make lines
@@ -189,13 +191,13 @@ let get_opam_info ~root ~pins packages =
   let packages = List.map
     (fun pkg ->
       let name = pkg.name in
-      let archive_url_line = Opam_show_result.get ~package:name ~field:"url.src" data in
+      let archive_url_line = Opam_show_result.get ~package:name ~field:"url.src:" data in
       let archive = parse_archive_url ~package:name archive_url_line
       in
-      let dev_repo_line = Opam_show_result.get ~package:name ~field:"dev-repo" data in
+      let dev_repo_line = Opam_show_result.get ~package:name ~field:"dev-repo:" data in
       let dev_repo = parse_dev_repo ~package:name dev_repo_line
       in
-      let depends_line = Opam_show_result.get ~package:name ~field:"depends" data in
+      let depends_line = Opam_show_result.get ~package:name ~field:"depends:" data in
       let depends = parse_opam_depends ~package:name depends_line
       in
       dev_repo >>= fun dev_repo ->

--- a/lib/opam_cmd.ml
+++ b/lib/opam_cmd.ml
@@ -125,7 +125,10 @@ let classify_package ~package ~dev_repo ~archive ~pins () =
             | false -> (`Unknown host, tag) )
           | None -> err "dev-repo without host" ) )
 
-let extract_opam_value = function
+(* Fetch and parse an opam field from an Opam_show_result.t*)
+let extract_opam_value ~field ~package data =
+  let v = Opam_show_result.get ~field ~package data in
+  match v with
   | None -> None
   | Some str ->
       let res =
@@ -136,9 +139,9 @@ let extract_opam_value = function
       in
       Some res
 
-let parse_string ~field ~package v =
+let parse_string ~field ~package data =
   let open OpamParserTypes in
-  match extract_opam_value v with
+  match extract_opam_value ~field ~package data with
   | Some (Ok (String (_, v))) -> Ok v
   | Some (Ok (List (_, []))) -> Ok ""
   | None -> Ok ""
@@ -147,14 +150,14 @@ let parse_string ~field ~package v =
         (Fmt.strf "Unable to parse opam string.\nTry `opam show --normalise -f %s: %s`" field
            package)
 
-let parse_dev_repo = parse_string ~field:"dev-repo"
+let parse_dev_repo = parse_string ~field:"dev-repo:"
 
-let parse_archive_url ~package v =
-  parse_string ~field:"url.src" ~package v >>= function "" -> Ok None | uri -> Ok (Some uri)
+let parse_archive_url ~package data =
+  parse_string ~field:"url.src:" ~package data >>= function "" -> Ok None | uri -> Ok (Some uri)
 
-let parse_opam_depends ~package v =
+let parse_opam_depends ~package data =
   let open OpamParserTypes in
-  match extract_opam_value v with
+  match extract_opam_value ~field:"depends:" ~package data with
   | Some (Ok (List (_, vs))) ->
       let ss =
         List.fold_left
@@ -180,12 +183,9 @@ let get_opam_info ~root ~pins packages =
     List.map
       (fun pkg ->
         let name = pkg.name in
-        let archive_url_line = Opam_show_result.get ~package:name ~field:"url.src:" data in
-        let archive = parse_archive_url ~package:name archive_url_line in
-        let dev_repo_line = Opam_show_result.get ~package:name ~field:"dev-repo:" data in
-        let dev_repo = parse_dev_repo ~package:name dev_repo_line in
-        let depends_line = Opam_show_result.get ~package:name ~field:"depends:" data in
-        let depends = parse_opam_depends ~package:name depends_line in
+        let archive = parse_archive_url ~package:name data in
+        let dev_repo = parse_dev_repo ~package:name data in
+        let depends = parse_opam_depends ~package:name data in
         dev_repo >>= fun dev_repo ->
         archive >>= fun archive ->
         depends >>| fun depends ->

--- a/lib/opam_show_result.ml
+++ b/lib/opam_show_result.ml
@@ -1,0 +1,64 @@
+open Astring
+
+module StrMap = Map.Make(String)
+
+let empty = StrMap.empty
+
+type t = string StrMap.t StrMap.t
+
+let parse_opam_show_line line =
+  let drop = function
+  | ':' -> true
+  | x when Char.Ascii.is_white x -> true
+  | _ -> false
+  in
+  match String.cut ~sep:" " line with
+  | None -> "",""
+  | Some (field, value) -> (String.trim ~drop field, String.trim value)
+
+let add ~package ~field ~value t =
+StrMap.update
+    package
+    (function
+    | None -> Some (StrMap.singleton field value)
+    | Some fields -> Some (StrMap.add field value fields))
+    t
+
+let make lines =
+    let rec loop cur_name t = function
+    | [] -> Ok t
+    | line::next -> (
+        match (cur_name, parse_opam_show_line line) with
+        | (_, ("name", pkg_name)) -> loop (Some pkg_name) t next
+        | (None, _) -> Error (`Msg "")
+        | (Some package, (field, value)) ->
+            let t = add ~package ~field ~value t in
+            loop cur_name t next
+    )
+    in
+    loop None empty lines
+
+
+let get ~package ~field t =
+    match StrMap.find_opt package t with
+    | None -> None
+    | Some fields -> StrMap.find_opt field fields
+
+let from_list lst =
+    List.fold_left
+        (fun map (package,field,value)-> add ~package ~field ~value map)
+        StrMap.empty
+        lst
+
+let bindings t =
+    let bindings_map = StrMap.map StrMap.bindings t in
+    StrMap.bindings bindings_map
+
+let equal = StrMap.equal (StrMap.equal String.equal)
+
+
+
+let pp fmt t =
+    let open Sexplib.Std in
+    let sxp = [%sexp_of: (string * (string * string) list) list] (bindings t) in
+    Sexplib.Sexp.pp_hum fmt sxp

--- a/lib/opam_show_result.ml
+++ b/lib/opam_show_result.ml
@@ -1,59 +1,60 @@
 open Astring
-
-module StrMap = Map.Make(String)
+module StrMap = Map.Make (String)
 
 let empty = StrMap.empty
 
 type t = string StrMap.t StrMap.t
 
+(* Separate an opam show output line into two trimmed strings. *)
 let parse_opam_show_line line =
   match String.cut ~sep:" " line with
-  | None -> "",""
+  | None -> ("", "")
   | Some (field, value) -> (String.trim field, String.trim value)
 
+(* Add a field -> value mapping to a package. *)
 let add ~package ~field ~value t =
-StrMap.update
-    package
+  StrMap.update package
     (function
-    | None -> Some (StrMap.singleton field value)
-    | Some fields -> Some (StrMap.add field value fields))
+      | None -> Some (StrMap.singleton field value)
+      | Some fields -> Some (StrMap.add field value fields) )
     t
 
+(** [make lines] builds an Opam_show_result.t from an opam show output.
+    The first field for each package must be 'name'*)
 let make lines =
-    let rec loop cur_name t = function
+  let rec loop cur_name t = function
     | [] -> Ok t
-    | line::next -> (
-        match (cur_name, parse_opam_show_line line) with
-        | (_, ("name", pkg_name)) -> loop (Some pkg_name) t next
-        | (None, _) -> Error (`Msg "")
-        | (Some package, (field, value)) ->
-            let t = add ~package ~field ~value t in
-            loop cur_name t next
-    )
-    in
-    loop None empty lines
+    | line :: next -> (
+      match (cur_name, parse_opam_show_line line) with
+      | _, ("name", pkg_name) -> loop (Some pkg_name) t next
+      | None, _ -> Error (`Msg "")
+      | Some package, (field, value) ->
+          let t = add ~package ~field ~value t in
+          loop cur_name t next )
+  in
+  loop None empty lines
 
-
+(** [get ~package ~field t] retrieves a field from a package. Returns
+    None if the package or the field doesn't exist. *)
 let get ~package ~field t =
-    match StrMap.find_opt package t with
-    | None -> None
-    | Some fields -> StrMap.find_opt field fields
+  match StrMap.find_opt package t with None -> None | Some fields -> StrMap.find_opt field fields
 
+(** [from_list bindings] builds an Opam_show_result.t from a list of
+    bindings (package, field, value). *)
 let from_list lst =
-    List.fold_left
-        (fun map (package,field,value)-> add ~package ~field ~value map)
-        StrMap.empty
-        lst
+  List.fold_left
+    (fun map (package, field, value) -> add ~package ~field ~value map)
+    StrMap.empty lst
 
 let bindings t =
-    let bindings_map = StrMap.map StrMap.bindings t in
-    StrMap.bindings bindings_map
+  let bindings_map = StrMap.map StrMap.bindings t in
+  StrMap.bindings bindings_map
 
+(** Equality test on Opam_show_result.t *)
 let equal = StrMap.equal (StrMap.equal String.equal)
 
-
-
+(** Pretty-printer *)
 let pp fmt t =
-    let open Sexplib.Std in
-    let sxp = [%sexp_of: (string * (string * string) list) list] (bindings t) in
-    Sexplib.Sexp.pp_hum fmt sxp
+  let open Sexplib.Std in
+  let sxp = [%sexp_of: (string * (string * string) list) list] (bindings t) in
+  Sexplib.Sexp.pp_hum fmt sxp

--- a/lib/opam_show_result.ml
+++ b/lib/opam_show_result.ml
@@ -7,14 +7,9 @@ let empty = StrMap.empty
 type t = string StrMap.t StrMap.t
 
 let parse_opam_show_line line =
-  let drop = function
-  | ':' -> true
-  | x when Char.Ascii.is_white x -> true
-  | _ -> false
-  in
   match String.cut ~sep:" " line with
   | None -> "",""
-  | Some (field, value) -> (String.trim ~drop field, String.trim value)
+  | Some (field, value) -> (String.trim field, String.trim value)
 
 let add ~package ~field ~value t =
 StrMap.update

--- a/lib/opam_show_result.mli
+++ b/lib/opam_show_result.mli
@@ -1,10 +1,19 @@
 type t
 
+val make : string list -> (t, [> Rresult.R.msg ]) result
 (** [make lines] builds an Opam_show_result.t from an opam show output.
     The first field for each package must be 'name'*)
-val make : string list -> (t, [>Rresult.R.msg]) result
+
 val from_list : (string * string * string) list -> t
-val get : package: string -> field: string -> t -> string option
+(** [from_list bindings] builds an Opam_show_result.t from a list of
+    bindings (package, field, value). *)
+
+val get : package:string -> field:string -> t -> string option
+(** [get ~package ~field t] retrieves a field from a package. Returns
+    None if the package or the field doesn't exist. *)
 
 val equal : t -> t -> bool
+(** Equality test on Opam_show_result.t *)
+
 val pp : Format.formatter -> t -> unit
+(** Pretty-printer *)

--- a/lib/opam_show_result.mli
+++ b/lib/opam_show_result.mli
@@ -1,0 +1,10 @@
+type t
+
+(** [make lines] builds an Opam_show_result.t from an opam show output.
+    The first field for each package must be 'name'*)
+val make : string list -> (t, [>Rresult.R.msg]) result
+val from_list : (string * string * string) list -> t
+val get : package: string -> field: string -> t -> string option
+
+val equal : t -> t -> bool
+val pp : Format.formatter -> t -> unit

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -18,8 +18,6 @@ open Sexplib.Conv
 
 let pp_sexp fn ppf v = Fmt.pf ppf "%s" (Sexplib.Sexp.to_string_hum (fn v))
 
-module StrMap = Map.Make(String)
-
 module Opam = struct
   module Remote = struct
     type t = { name : string; url : string } [@@deriving sexp]

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -18,6 +18,8 @@ open Sexplib.Conv
 
 let pp_sexp fn ppf v = Fmt.pf ppf "%s" (Sexplib.Sexp.to_string_hum (fn v))
 
+module StrMap = Map.Make(String)
+
 module Opam = struct
   module Remote = struct
     type t = { name : string; url : string } [@@deriving sexp]

--- a/test/test_duniverse_lib.ml
+++ b/test/test_duniverse_lib.ml
@@ -1,6 +1,5 @@
 let () =
-  Alcotest.run
-    "Duniverse"
-    [ "Opam_cmd", Test_opam_cmd.test_tag_from_archive
-    ; "Opam_show_result", Test_opam_show_result.test_make
+  Alcotest.run "Duniverse"
+    [ ("Opam_cmd", Test_opam_cmd.test_tag_from_archive);
+      ("Opam_show_result", Test_opam_show_result.test_make)
     ]

--- a/test/test_duniverse_lib.ml
+++ b/test/test_duniverse_lib.ml
@@ -1,1 +1,6 @@
-let () = Alcotest.run "Duniverse" [ ("Opam_cmd", Test_opam_cmd.test_tag_from_archive) ]
+let () =
+  Alcotest.run
+    "Duniverse"
+    [ "Opam_cmd", Test_opam_cmd.test_tag_from_archive
+    ; "Opam_show_result", Test_opam_show_result.test_make
+    ]

--- a/test/test_opam_show_result.ml
+++ b/test/test_opam_show_result.ml
@@ -20,36 +20,36 @@ let test_make =
             ~input:["name       test"; "url   bonjour.com"]
             ~expected:[("test","url", "bonjour.com")];
         make_test
-            ~name:"1 field (name with colon)"
-            ~input:["name:       test"; "url   bonjour.com"]
-            ~expected:[("test","url", "bonjour.com")];
+            ~name:"1 field (field key with colon)"
+            ~input:["name       test"; "url:   bonjour.com"]
+            ~expected:[("test","url:", "bonjour.com")];
         make_test
             ~name:"2 fields"
             ~input:
-                ["name:       test"
-                ;"url   bonjour.com"
+                ["name       test"
+                ;"url:   bonjour.com"
                 ;{|field2   ["salut"]|}]
             ~expected:
                 [("test","field2", {|["salut"]|})
-                ;("test","url", "bonjour.com")];
+                ;("test","url:", "bonjour.com")];
         make_test
             ~name:"with name field"
             ~input:
-                ["name:       test"
-                ;"url   bonjour.com"
-                ;"name:   test"
-                ;{|field2   ["salut"]|}]
-            ~expected:
-                [("test","field2", {|["salut"]|})
-                ;("test","url", "bonjour.com")];
-        make_test
-            ~name:"multiple packages"
-            ~input:
-                ["name:       test2"
-                ;"url   bonjour.com"
+                ["name       test"
+                ;"url:   bonjour.com"
                 ;"name   test"
                 ;{|field2   ["salut"]|}]
             ~expected:
                 [("test","field2", {|["salut"]|})
-                ;("test2","url", "bonjour.com")];
+                ;("test","url:", "bonjour.com")];
+        make_test
+            ~name:"multiple packages"
+            ~input:
+                ["name       test2"
+                ;"url:   bonjour.com"
+                ;"name   test"
+                ;{|field2   ["salut"]|}]
+            ~expected:
+                [("test","field2", {|["salut"]|})
+                ;("test2","url:", "bonjour.com")];
 ]

--- a/test/test_opam_show_result.ml
+++ b/test/test_opam_show_result.ml
@@ -1,0 +1,55 @@
+open Duniverse_lib
+
+let test_make =
+    let make_test ~name ~input ~expected =
+        let test_name = "make ("^name^")" in
+        let test_fun () =
+            let expected_t = Opam_show_result.from_list expected in
+            let actual = Rresult.R.get_ok (Opam_show_result.make input) in
+            Alcotest.(check (module Opam_show_result) name expected_t actual)
+        in
+        (test_name, `Quick, test_fun)
+    in
+    [
+        make_test
+            ~name:"empty"
+            ~input:[]
+            ~expected:[];
+        make_test
+            ~name:"1 field"
+            ~input:["name       test"; "url   bonjour.com"]
+            ~expected:[("test","url", "bonjour.com")];
+        make_test
+            ~name:"1 field (name with colon)"
+            ~input:["name:       test"; "url   bonjour.com"]
+            ~expected:[("test","url", "bonjour.com")];
+        make_test
+            ~name:"2 fields"
+            ~input:
+                ["name:       test"
+                ;"url   bonjour.com"
+                ;{|field2   ["salut"]|}]
+            ~expected:
+                [("test","field2", {|["salut"]|})
+                ;("test","url", "bonjour.com")];
+        make_test
+            ~name:"with name field"
+            ~input:
+                ["name:       test"
+                ;"url   bonjour.com"
+                ;"name:   test"
+                ;{|field2   ["salut"]|}]
+            ~expected:
+                [("test","field2", {|["salut"]|})
+                ;("test","url", "bonjour.com")];
+        make_test
+            ~name:"multiple packages"
+            ~input:
+                ["name:       test2"
+                ;"url   bonjour.com"
+                ;"name   test"
+                ;{|field2   ["salut"]|}]
+            ~expected:
+                [("test","field2", {|["salut"]|})
+                ;("test2","url", "bonjour.com")];
+]

--- a/test/test_opam_show_result.ml
+++ b/test/test_opam_show_result.ml
@@ -1,55 +1,29 @@
 open Duniverse_lib
 
 let test_make =
-    let make_test ~name ~input ~expected =
-        let test_name = "make ("^name^")" in
-        let test_fun () =
-            let expected_t = Opam_show_result.from_list expected in
-            let actual = Rresult.R.get_ok (Opam_show_result.make input) in
-            Alcotest.(check (module Opam_show_result) name expected_t actual)
-        in
-        (test_name, `Quick, test_fun)
+  let make_test ~name ~input ~expected =
+    let test_name = "make (" ^ name ^ ")" in
+    let test_fun () =
+      let expected_t = Opam_show_result.from_list expected in
+      let actual = Rresult.R.get_ok (Opam_show_result.make input) in
+      Alcotest.(check (module Opam_show_result) name expected_t actual)
     in
-    [
-        make_test
-            ~name:"empty"
-            ~input:[]
-            ~expected:[];
-        make_test
-            ~name:"1 field"
-            ~input:["name       test"; "url   bonjour.com"]
-            ~expected:[("test","url", "bonjour.com")];
-        make_test
-            ~name:"1 field (field key with colon)"
-            ~input:["name       test"; "url:   bonjour.com"]
-            ~expected:[("test","url:", "bonjour.com")];
-        make_test
-            ~name:"2 fields"
-            ~input:
-                ["name       test"
-                ;"url:   bonjour.com"
-                ;{|field2   ["salut"]|}]
-            ~expected:
-                [("test","field2", {|["salut"]|})
-                ;("test","url:", "bonjour.com")];
-        make_test
-            ~name:"with name field"
-            ~input:
-                ["name       test"
-                ;"url:   bonjour.com"
-                ;"name   test"
-                ;{|field2   ["salut"]|}]
-            ~expected:
-                [("test","field2", {|["salut"]|})
-                ;("test","url:", "bonjour.com")];
-        make_test
-            ~name:"multiple packages"
-            ~input:
-                ["name       test2"
-                ;"url:   bonjour.com"
-                ;"name   test"
-                ;{|field2   ["salut"]|}]
-            ~expected:
-                [("test","field2", {|["salut"]|})
-                ;("test2","url:", "bonjour.com")];
-]
+    (test_name, `Quick, test_fun)
+  in
+  [ make_test ~name:"empty" ~input:[] ~expected:[];
+    make_test ~name:"1 field"
+      ~input:[ "name       test"; "url   bonjour.com" ]
+      ~expected:[ ("test", "url", "bonjour.com") ];
+    make_test ~name:"1 field (field key with colon)"
+      ~input:[ "name       test"; "url:   bonjour.com" ]
+      ~expected:[ ("test", "url:", "bonjour.com") ];
+    make_test ~name:"2 fields"
+      ~input:[ "name       test"; "url:   bonjour.com"; {|field2   ["salut"]|} ]
+      ~expected:[ ("test", "field2", {|["salut"]|}); ("test", "url:", "bonjour.com") ];
+    make_test ~name:"with name field"
+      ~input:[ "name       test"; "url:   bonjour.com"; "name   test"; {|field2   ["salut"]|} ]
+      ~expected:[ ("test", "field2", {|["salut"]|}); ("test", "url:", "bonjour.com") ];
+    make_test ~name:"multiple packages"
+      ~input:[ "name       test2"; "url:   bonjour.com"; "name   test"; {|field2   ["salut"]|} ]
+      ~expected:[ ("test", "field2", {|["salut"]|}); ("test2", "url:", "bonjour.com") ]
+  ]

--- a/test/test_opam_show_result.mli
+++ b/test/test_opam_show_result.mli
@@ -1,0 +1,1 @@
+val test_make : unit Alcotest.test_case list


### PR DESCRIPTION
Instead of calling opam three times per package dependency, fetch and parse everything at once.
This is _a lot_ faster.