### PR TITLE
Use a temporary empty switch for dependencies resolution

### DIFF
--- a/bin/duniverse.ml
+++ b/bin/duniverse.ml
@@ -97,18 +97,6 @@ let pins_t =
   let t = Arg.conv ~docv:"PIN" (fin, fout) in
   Arg.(value & opt_all t [] & info ["pin"; "p"] ~docv:"PIN" ~doc)
 
-let ocaml_switch_t =
-  let doc =
-    "Name of the OCaml compiler to use to resolve opam packages.  A local \
-     switch is created in $(i,.duniverse) where pins and packages can be \
-     tracked independently of your main opam switch.  This defaults to \
-     $(i,ocaml-system), but you can use this flag to supply a more specific \
-     version such as $(b,ocaml.4.06.1)."
-  in
-  let open Arg in
-  value & opt string "ocaml-system"
-  & info ["opam-switch"; "s"] ~docv:"OPAM_SWITCH" ~doc
-
 let pkg_t =
   let open Arg in
   value & pos_all string []
@@ -137,7 +125,7 @@ let opam_cmd =
   ( (let open Term in
     term_result
       ( const Opam_cmd.init_duniverse
-      $ target_repo_t $ branch_t $ pkg_t $ exclude_t $ pins_t $ ocaml_switch_t
+      $ target_repo_t $ branch_t $ pkg_t $ exclude_t $ pins_t
       $ remotes_t $ setup_logs () ))
   , Term.info "opam" ~doc ~exits ~man )
 

--- a/lib/exec.ml
+++ b/lib/exec.ml
@@ -203,9 +203,14 @@ let get_opam_depends ~root package =
             Try `opam show --normalise -f depends: %s` manually"
            package package)
 
-let opam_init ~root ~compiler () =
+let opam_init_bare ~root () =
   let open Cmd in
-  let cmd = opam_cmd ~root "init" % ("--compiler=" ^ compiler) % "--no-setup" in
+  let cmd = opam_cmd ~root "init" % "--no-setup" % "--bare" in
+  run_and_log cmd
+
+let opam_switch_create_empty ~root () =
+  let open Cmd in
+  let cmd = opam_cmd ~root "switch" % "create" % "empty" % "--empty" % "--no-install" in
   run_and_log cmd
 
 let opam_add_remote ~root {Types.Opam.Remote.name; url} =
@@ -213,9 +218,11 @@ let opam_add_remote ~root {Types.Opam.Remote.name; url} =
   let cmd = opam_cmd ~root "repository" % "add" % name % url in
   run_and_log cmd 
 
-let init_opam_and_remotes ~root ~compiler ~remotes () =
-  Logs.info (fun l -> l "Initialising a fresh local opam switch in %a." Fpath.pp root);
-  opam_init ~root ~compiler ()
+let init_opam_and_remotes ~root ~remotes () =
+  Logs.info (fun l -> l "Initialising a fresh temprorary opam with an empty switch in %a." Fpath.pp root);
+  opam_init_bare ~root ()
+  >>= fun () ->
+  opam_switch_create_empty ~root ()
   >>= fun () ->
   iter (opam_add_remote ~root) remotes
 

--- a/lib/exec.mli
+++ b/lib/exec.mli
@@ -86,12 +86,10 @@ val get_opam_archive_url : root: Fpath.t -> string -> (string option, [> Rresult
     resolves the transitive dependencies of [packages]. *)
 val run_opam_package_deps : root: Fpath.t -> string list -> (string list, [> Rresult.R.msg]) result
 
-(** [init_local_opam_switch ~opam_switch ~root ~remotes ()] creates a fresh opam state and switch
-    with compiler [compiler] using [root] as OPAMROOT and adds the [remotes] opam repositories
-    to it. *)
+(** [init_local_opam_switch ~root ~remotes ()] creates a fresh opam state with a single
+    switch using [root] as OPAMROOT and adds the [remotes] opam repositories to it. *)
 val init_opam_and_remotes :
   root: Fpath.t ->
-  compiler: string ->
   remotes: Types.Opam.Remote.t list ->
   unit ->
   (unit, [> Rresult.R.msg]) result

--- a/lib/git_cmd.ml
+++ b/lib/git_cmd.ml
@@ -21,11 +21,11 @@ let pp_header = Fmt.(styled `Blue string)
 
 let header = ">>> "
 
-let update repo branch roots excludes pins opam_switch remotes () =
+let update repo branch roots excludes pins remotes () =
   Exec.git_checkout ~repo branch
   >>= fun () ->
   Logs.info (fun l -> l "Running `duniverse opam`") ;
-  Opam_cmd.init_duniverse repo branch roots excludes pins opam_switch remotes
+  Opam_cmd.init_duniverse repo branch roots excludes pins remotes
     ()
   >>= fun () ->
   Logs.info (fun l -> l "Running `duniverse lock`") ;

--- a/lib/opam_cmd.ml
+++ b/lib/opam_cmd.ml
@@ -198,7 +198,7 @@ let filter_duniverse_packages ~excludes pkgs =
 
 let calculate_duniverse ~root file =
   load file
-  >>= fun {roots; excludes; pins; opam_switch; branch; remotes; _} ->
+  >>= fun {roots; excludes; pins; branch; remotes; _} ->
   Exec.run_opam_package_deps ~root (List.map string_of_package roots)
   >>| List.map split_opam_name_and_version
   >>| List.map (fun p ->
@@ -233,7 +233,7 @@ let calculate_duniverse ~root file =
   let num_dune = List.length is_dune_pkgs in
   let num_not_dune = List.length not_dune_pkgs in
   let num_total = List.length pkgs in
-  let t = {pkgs; roots; excludes; pins; opam_switch; branch; remotes} in
+  let t = {pkgs; roots; excludes; pins; branch; remotes} in
   if num_not_dune > 0 then
     Logs.app (fun l ->
         l
@@ -271,7 +271,7 @@ let init_opam ~root ~remotes () =
   in
   Exec.init_opam_and_remotes ~root ~remotes:(dune_overlays::user_specified_remotes) ()
 
-let init_duniverse repo branch roots excludes pins compiler remotes () =
+let init_duniverse repo branch roots excludes pins remotes () =
   Logs.app (fun l ->
       l "%aCalculating Duniverse on the %a branch." pp_header header
         Fmt.(styled `Cyan string)
@@ -329,5 +329,5 @@ let init_duniverse repo branch roots excludes pins compiler remotes () =
     List.map split_opam_name_and_version (locals @ excludes) |> sort_uniq
   in
   let roots = List.map split_opam_name_and_version roots |> sort_uniq in
-  save file {pkgs= []; roots; excludes; pins; opam_switch = compiler; branch; remotes}
+  save file {pkgs= []; roots; excludes; pins; branch; remotes}
   >>= fun () -> calculate_duniverse ~root file

--- a/lib/opam_cmd.ml
+++ b/lib/opam_cmd.ml
@@ -263,13 +263,13 @@ let calculate_duniverse ~root file =
         file ) ;
   Ok ()
 
-let init_opam ~root ~compiler ~remotes () =
+let init_opam ~root ~remotes () =
   let open Types.Opam.Remote in
   let dune_overlays = {name = "dune-overlays"; url = Config.duniverse_overlays_repo} in
   let user_specified_remotes =
     List.mapi (fun i url -> {name = Fmt.strf "remote%d" i; url}) remotes
   in
-  Exec.init_opam_and_remotes ~root ~compiler ~remotes:(dune_overlays::user_specified_remotes) ()
+  Exec.init_opam_and_remotes ~root ~remotes:(dune_overlays::user_specified_remotes) ()
 
 let init_duniverse repo branch roots excludes pins compiler remotes () =
   Logs.app (fun l ->
@@ -281,7 +281,7 @@ let init_duniverse repo branch roots excludes pins compiler remotes () =
   >>= fun root ->
   Bos.OS.Dir.create Fpath.(repo // duniverse_dir)
   >>= fun _ ->
-  init_opam ~compiler ~root ~remotes ()
+  init_opam ~root ~remotes ()
   >>= fun () ->
   Exec.(iter (add_opam_dev_pin ~root) pins)
   >>= fun () ->

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -60,8 +60,7 @@ module Opam = struct
     ; pins: pin list
     ; pkgs: entry list
     ; remotes: string list [@default []]
-    ; branch: string [@default "master"]
-    ; opam_switch: string }
+    ; branch: string [@default "master"] }
   [@@deriving sexp]
 
   let pp_repo = pp_sexp sexp_of_repo


### PR DESCRIPTION
As a followup to #8 and #9 `duniverse opam` now uses an temporary opam state with an empty switch.

This makes it much faster as we don't have to compile ocaml anymore.
The output of `opam list --resolve` will now give us a bunch of new dependencies such as `ocaml-base-compiler` and `base-bigarray` but they are properly handled by `classify_package`. This was a bit cryptic and hard to figure out so we should probably improve that part of the code in the future but it works for now.

As a side effect, the `Opam_cmd.init_duniverse` function doesn't need the `compiler` argument anymore so I removed it, both from the command line arguments and from the `Types.Opam.t` type. Be aware that this is a breaking change to `duniverse opam` and `duniverse lock`.

Another point worth noting is that now, unless users specify an ocaml version in their `.opam` files, the solver will pick one by itself so we should probably encourage explicitly define one.

Let me know what you think!