### PR TITLE
Add integration tests

### DIFF
--- a/.docker.sh
+++ b/.docker.sh
@@ -16,3 +16,6 @@ opam update
 opam install --deps-only -t duniverse
 make
 make test
+make install
+cd examples
+./build-examples.sh

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build clean test doc
+.PHONY: build clean test doc install
 
 build:
 	dune build 
@@ -11,3 +11,6 @@ doc:
 
 test:
 	dune runtest
+
+install:
+	dune install

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
-(lang dune 1.2)
+(lang dune 1.6)
 (name duniverse)

--- a/examples/basic/basic.ml
+++ b/examples/basic/basic.ml
@@ -1,0 +1,3 @@
+let () =
+  let _ = Rresult.Ok () in
+  Fmt.pf Format.std_formatter "hello!\n"

--- a/examples/basic/basic.opam
+++ b/examples/basic/basic.opam
@@ -1,0 +1,6 @@
+opam-version: "2.0"
+depends: [
+  "dune" {build >= "1.2.0"}
+  "fmt" {>= "0.8.5" & < "0.8.7"}
+  "rresult"
+]

--- a/examples/basic/dune
+++ b/examples/basic/dune
@@ -1,0 +1,3 @@
+(executable
+  (public_name basic)
+  (libraries fmt rresult))

--- a/examples/basic/dune-project
+++ b/examples/basic/dune-project
@@ -1,0 +1,2 @@
+(lang dune 1.2)
+(name basic)

--- a/examples/build-examples.sh
+++ b/examples/build-examples.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+(
+  cd basic
+  duniverse opam
+  duniverse lock
+  duniverse pull
+  dune build --profile release --root=.
+  [[ -e _build/default/basic.exe ]]
+)

--- a/examples/dune
+++ b/examples/dune
@@ -1,0 +1,1 @@
+(data_only_dirs *)


### PR DESCRIPTION
Depends on #12 on top of which it is rebased. This is required to have a fast enough CI as compiling ocaml in a docker was terribly slow.

Only the last commit is relevant to this PR, please don't merge before #12 !

This PR adds a simple integration test. We build a simple binary which depends both on a regular upstream packages and a dune-overlay one using `duniverse` and make sure everything work fine.

As I was working on this I figured we could probably improve our CI to make better use of the docker's cache but this can be done separately!