### PR TITLE
Mark the package as virtual when the url field is not understood

### DIFF
--- a/lib/opam_cmd.ml
+++ b/lib/opam_cmd.ml
@@ -122,7 +122,13 @@ let classify_package ~package ~dev_repo ~archive ~pins () =
             | true ->
                 let base_repo = String.cuts ~empty:false ~sep:"#" archive |> List.hd in
                 (`Git base_repo, tag)
-            | false -> (`Unknown host, tag) )
+            | false ->
+                Logs.debug (fun l ->
+                    l
+                      "Mapped %s to a virtual package as its source url (%s) is not understood by \
+                       duniverse"
+                      package.name host );
+                (`Virtual, tag) )
           | None -> err "dev-repo without host" ) )
 
 let check_if_dune ~root package =
@@ -151,8 +157,6 @@ let package_is_valid { package; dev_repo; _ } =
   match dev_repo with
   | `Error msg ->
       R.error_msg (Fmt.strf "Do not know how to deal with %a: %s" pp_package package msg)
-  | `Unknown msg ->
-      R.error_msg (Fmt.strf "Need a Duniverse fork for %a: %s" pp_package package msg)
   | _ -> R.ok ()
 
 let check_packages_are_valid pkgs =

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -25,12 +25,7 @@ module Opam = struct
     let pp = pp_sexp sexp_of_t
   end
 
-  type repo =
-    [ `Github of string * string
-    | `Git of string
-    | `Unknown of string
-    | `Virtual
-    | `Error of string ]
+  type repo = [ `Github of string * string | `Git of string | `Virtual | `Error of string ]
   [@@deriving sexp]
 
   type package = { name : string; version : string option [@default None] [@sexp_drop_default] }


### PR DESCRIPTION
Right now `ocamlfind` is classified as `Unknown` which leads to hard failure while executing `duniverse opam`. This is because `dev-repo` and url fields are filled but duniverse cannot do anything with them.
Instead of failing, I simply suggest to mark the package as `Virtual`, like it's done for other packages that are duniverse-incompatible.

This solves the problem I have introduced in #14.