### PR TITLE
duniverse opam-install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ COMMANDS
            analyse opam metadata to generate a standalone package list
 
        opam-install
-           install packages that are not dune-compatible via opam
+           install packages that are not duniverse-compatible via opam
 
        pull
            fetch the latest archives of the vendored libraries

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ COMMANDS
        opam
            analyse opam metadata to generate a standalone package list
 
+       opam-install
+           install packages that are not dune-compatible via opam
+
        pull
            fetch the latest archives of the vendored libraries
 

--- a/bin/duniverse.ml
+++ b/bin/duniverse.ml
@@ -66,6 +66,10 @@ let remotes_t =
   in
   Arg.(value & opt_all string [] & info [ "opam-remote" ] ~docv:"OPAM_REMOTE" ~doc)
 
+let yes_t =
+  let doc = "Answer yes to all yes/no questions without prompting." in
+  Arg.(value & flag & info [ "yes"; "y" ] ~doc)
+
 let pins_t =
   let open Types.Opam in
   let doc =
@@ -122,6 +126,21 @@ let opam_cmd =
       ( const Opam_cmd.init_duniverse $ target_repo_t $ branch_t $ pkg_t $ exclude_t $ pins_t
       $ remotes_t $ setup_logs () )),
     Term.info "opam" ~doc ~exits ~man )
+
+let opam_install_cmd =
+  let doc = "install packages that are not dune-compatible via opam" in
+  let exits = Term.default_exits in
+  let man =
+    [ `S Manpage.s_description;
+      `P
+        "This command generates and execute an opam command that will install dune-incompatible \
+         packages in the global opam switch. By default it prompts for confirmation."
+    ]
+  in
+  ( (let open Term in
+    term_result
+      (const Opam_cmd.install_incompatible_packages $ yes_t $ target_repo_t $ setup_logs ())),
+    Term.info "opam-install" ~doc ~exits ~man )
 
 let dune_lock_cmd =
   let doc = "generate git tags suitable for vendoring from opam metadata" in
@@ -209,6 +228,6 @@ let default_cmd =
   ( Term.(ret (const (fun _ -> `Help (`Pager, None)) $ pure ())),
     Term.info "duniverse" ~version:"%%VERSION%%" ~doc ~man_xrefs ~sdocs ~man )
 
-let cmds = [ opam_cmd; dune_lock_cmd; dune_fetch_cmd; status_cmd ]
+let cmds = [ opam_cmd; dune_lock_cmd; dune_fetch_cmd; status_cmd; opam_install_cmd ]
 
 let () = Term.(exit @@ eval_choice default_cmd cmds)

--- a/bin/duniverse.ml
+++ b/bin/duniverse.ml
@@ -128,13 +128,14 @@ let opam_cmd =
     Term.info "opam" ~doc ~exits ~man )
 
 let opam_install_cmd =
-  let doc = "install packages that are not dune-compatible via opam" in
+  let doc = "install packages that are not duniverse-compatible via opam" in
   let exits = Term.default_exits in
   let man =
     [ `S Manpage.s_description;
       `P
-        "This command generates and execute an opam command that will install dune-incompatible \
-         packages in the global opam switch. By default it prompts for confirmation."
+        "This command generates and execute an opam command that will install \
+         duniverse-incompatible packages in the global opam switch. By default it prompts for \
+         confirmation."
     ]
   in
   ( (let open Term in

--- a/lib/exec.ml
+++ b/lib/exec.ml
@@ -168,3 +168,12 @@ let add_opam_dev_pin ~root { Opam.pin; url; tag } =
 
 let add_opam_local_pin ~root package =
   run_and_log Cmd.(opam_cmd ~root "pin" % "add" % "-yn" % (package ^ ".dev") % ".")
+
+let run_opam_install ~yes packages =
+  let packages =
+    List.map
+      (fun (pkg : Types.Opam.package) ->
+        match pkg.version with Some v -> pkg.name ^ "." ^ v | None -> pkg.name )
+      packages
+  in
+  OS.Cmd.run Cmd.(v "opam" % "install" %% on yes (v "-y") %% of_list packages)

--- a/lib/exec.mli
+++ b/lib/exec.mli
@@ -74,3 +74,7 @@ val add_opam_dev_pin : root:Fpath.t -> Types.Opam.pin -> (unit, [> Rresult.R.msg
 val add_opam_local_pin : root:Fpath.t -> string -> (unit, [> Rresult.R.msg ]) result
 (** [add_opam_local_pin ~root package] pins the package in the current working dir under
     [package ^ ".dev"] in the active switch using [root] as OPAMROOT. *)
+
+val run_opam_install : yes:bool -> Types.Opam.package list -> (unit, [> Rresult.R.msg ]) result
+(** [run_opam_install ~yes packages] launch an opam command to install the given packages. If yes is
+    set to true, it doesn't prompt the user for confirmation. *)

--- a/lib/opam_cmd.ml
+++ b/lib/opam_cmd.ml
@@ -347,8 +347,8 @@ let init_duniverse repo branch explicit_root_packages excludes pins remotes () =
 
 let install_incompatible_packages yes repo () =
   let is_valid = function
-    | `Github _ | `Git _ -> true
-    | `Unknown _ | `Virtual | `Error _ -> false
+    | `Virtual | `Github _ | `Git _ -> true
+    | `Unknown _ | `Error _ -> false
   in
   Logs.app (fun l ->
       l "%aGathering dune-incompatible packages from %a." pp_header header
@@ -364,4 +364,9 @@ let install_incompatible_packages yes repo () =
   | [] ->
       Logs.app (fun l -> l "%aGood news! There is no package to install!" pp_header header);
       Ok ()
-  | packages_to_install -> Exec.run_opam_install ~yes packages_to_install
+  | packages_to_install ->
+      Logs.app (fun l ->
+          l "%aInstalling these packages with opam:\n%a" pp_header header
+            (Format.pp_print_list (fun fmt -> Format.fprintf fmt " - %a" pp_package))
+            packages_to_install );
+      Exec.run_opam_install ~yes packages_to_install

--- a/lib/opam_cmd.ml
+++ b/lib/opam_cmd.ml
@@ -367,6 +367,6 @@ let install_incompatible_packages yes repo () =
   | packages_to_install ->
       Logs.app (fun l ->
           l "%aInstalling these packages with opam:\n%a" pp_header header
-            (Format.pp_print_list (fun fmt -> Format.fprintf fmt " - %a" pp_package))
+            Fmt.(list ~sep:sp pp_package)
             packages_to_install );
       Exec.run_opam_install ~yes packages_to_install


### PR DESCRIPTION
A first and straightforward solution to https://github.com/avsm/duniverse/issues/19.

It keeps tracks of non-dune packages and allow to install them using `duniverse opam-install`. 