### PR TITLE
Improve tag_from_archive

### DIFF
--- a/lib/opam_cmd.ml
+++ b/lib/opam_cmd.ml
@@ -51,7 +51,9 @@ let tag_from_archive archive =
     | None -> parse_err ()
     | Some (_n, v) -> Some (prefix ^ v)
   in
-  let tag_of_last_path ?prefix () = List.rev path |> List.hd |> tag_of_file ?prefix in
+  let tag_of_last_path ?prefix () =
+    match List.rev path with file :: _ -> tag_of_file ?prefix file | [] -> None
+  in
   match Uri.scheme uri with
   | Some "git+http" | Some "git+https" | Some "git+ssh" | Some "git" -> (
     match String.cuts ~empty:false ~sep:"#" archive with

--- a/test/test_opam_cmd.ml
+++ b/test/test_opam_cmd.ml
@@ -1,38 +1,42 @@
 let test_tag_from_archive =
-  let make_test ~archive ~expected =
-    let test_name = "tag_from_archive: " ^ archive in
+  let make_test ?name ~archive ~expected () =
+    let name = match name with Some n -> n | None -> archive in
+    let test_name = "tag_from_archive: " ^ name in
     let test_fun () =
       let actual = Duniverse_lib.Opam_cmd.tag_from_archive archive in
       Alcotest.(check (option string)) archive expected actual
     in
     (test_name, `Quick, test_fun)
   in
-  [ make_test ~archive:"git+http://a.com/user/repo" ~expected:(Some "master");
-    make_test ~archive:"git+https://a.com/user/repo" ~expected:(Some "master");
-    make_test ~archive:"git+https://a.com/user/repo#v1.2.3" ~expected:(Some "v1.2.3");
-    make_test ~archive:"git+https://github.com/user/repo#v1.2.3" ~expected:(Some "v1.2.3");
-    make_test ~archive:"git+ssh://a.com/user/repo#v1.2.3" ~expected:(Some "v1.2.3");
-    make_test ~archive:"git+file://a.com/user/repo/something" ~expected:None;
+  [ make_test ~name:"empty" ~archive:"" ~expected:None ();
+    make_test ~archive:"malformed" ~expected:None ();
+    make_test ~archive:"git+http://a.com/user/repo" ~expected:(Some "master") ();
+    make_test ~archive:"git+https://a.com/user/repo" ~expected:(Some "master") ();
+    make_test ~archive:"git+https://a.com/user/repo#v1.2.3" ~expected:(Some "v1.2.3") ();
+    make_test ~archive:"git+https://github.com/user/repo#v1.2.3" ~expected:(Some "v1.2.3") ();
+    make_test ~archive:"git+ssh://a.com/user/repo#v1.2.3" ~expected:(Some "v1.2.3") ();
+    make_test ~archive:"git+file://a.com/user/repo/something" ~expected:None ();
     make_test ~archive:"https://github.com/user/repo/releases/download/v1.2.3/archive.tbz"
-      ~expected:(Some "v1.2.3");
-    make_test ~archive:"https://github.com/user/repo/archive/v1.2.3.tbz" ~expected:(Some "v1.2.3");
+      ~expected:(Some "v1.2.3") ();
+    make_test ~archive:"https://github.com/user/repo/archive/v1.2.3.tbz" ~expected:(Some "v1.2.3")
+      ();
     make_test ~archive:"https://github.com/user/repo/archive/v1.2.3/archive.tbz"
-      ~expected:(Some "v1.2.3");
+      ~expected:(Some "v1.2.3") ();
     make_test ~archive:"https://ocaml.janestreet.com/ocaml-core/4.07.1/files/package-v1.2.3.tbz"
-      ~expected:(Some "v1.2.3");
+      ~expected:(Some "v1.2.3") ();
     make_test
       ~archive:"https://ocaml.janestreet.com/janestreet/repo/releases/download/v1.2.3/file.tbz"
-      ~expected:(Some "v1.2.3");
+      ~expected:(Some "v1.2.3") ();
     make_test ~archive:"https://ocaml.janestreet.com/janestreet/repo/archive/v1.2.3.tbz"
-      ~expected:(Some "v1.2.3");
-    make_test ~archive:"https://ocaml.janestreet.com/janestreet/malformed" ~expected:None;
+      ~expected:(Some "v1.2.3") ();
+    make_test ~archive:"https://ocaml.janestreet.com/janestreet/malformed" ~expected:None ();
     make_test ~archive:"https://gitlab.camlcity.org/some/path/file-v1.2.3.tbz"
-      ~expected:(Some "v1.2.3");
+      ~expected:(Some "v1.2.3") ();
     make_test ~archive:"https://download.camlcity.org/some/path/file-v1.2.3.tbz"
-      ~expected:(Some "v1.2.3");
+      ~expected:(Some "v1.2.3") ();
     make_test ~archive:"https://ocamlgraph.lri.fr/some/path/file-1.2.3.tbz"
-      ~expected:(Some "v1.2.3");
-    make_test ~archive:"https://erratique.ch/some/path/file-1.2.3.tbz" ~expected:(Some "v1.2.3");
+      ~expected:(Some "v1.2.3") ();
+    make_test ~archive:"https://erratique.ch/some/path/file-1.2.3.tbz" ~expected:(Some "v1.2.3") ();
     make_test ~archive:"https://other.domain.com/some/path/file-v1.2.3.tbz"
-      ~expected:(Some "v1.2.3")
+      ~expected:(Some "v1.2.3") ()
   ]


### PR DESCRIPTION
This PR add a couple test and minor robustness improvements to the parsing of archive URLs.

It used to crash on empty archive fields and although this should not happen, better be safe than sorry.