### PR TITLE
Remove GitHub variant from dev_repo

### DIFF
--- a/lib/dune_cmd.ml
+++ b/lib/dune_cmd.ml
@@ -25,12 +25,6 @@ let header = "==> "
 let dune_repo_of_opam opam =
   let dir = Opam.(opam.package.name) in
   match opam.Opam.dev_repo with
-  | `Github (user, repo) -> (
-      let upstream = Fmt.strf "https://github.com/%s/%s.git" user repo in
-      match opam.Opam.tag with
-      | None ->
-          Exec.git_default_branch ~remote:upstream () >>= fun ref -> Ok { Dune.dir; upstream; ref }
-      | Some ref -> Ok { Dune.dir; upstream; ref } )
   | `Git upstream -> (
     match opam.Opam.tag with
     | None ->

--- a/lib/opam_cmd.ml
+++ b/lib/opam_cmd.ml
@@ -107,12 +107,6 @@ let classify_package ~package ~dev_repo ~archive ~pins () =
           match Opam.Dev_repo.from_string dev_repo with
           | { vcs = Some Git; uri = dev_repo_uri } -> (
             match Uri.host dev_repo_uri with
-            | Some "github.com" -> (
-              match String.cuts ~empty:false ~sep:"/" (Uri.path dev_repo_uri) with
-              | [ user; repo ] ->
-                  let repo = strip_ext repo in
-                  (`Github (user, repo), tag)
-              | _ -> err "weird github url" )
             | Some _host -> (`Git (Uri.to_string dev_repo_uri), tag)
             | None -> err "dev-repo without host" )
           | { vcs = None | Some (Other _); _ } -> (`Error "dev-repo doesn't use git as a VCS", None)
@@ -316,10 +310,7 @@ let choose_root_packages ~explicit_root_packages ~local_packages =
       Ok explicit_root_packages
 
 let install_incompatible_packages yes repo =
-  let is_valid = function
-    | `Virtual | `Github _ | `Git _ -> true
-    | `Unknown _ | `Error _ -> false
-  in
+  let is_valid = function `Virtual | `Git _ -> true | `Unknown _ | `Error _ -> false in
   Logs.app (fun l ->
       l "%aGathering dune-incompatible packages from %a." pp_header header
         Fmt.(styled `Cyan Fpath.pp)

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -25,16 +25,13 @@ module Opam = struct
     let pp = pp_sexp sexp_of_t
   end
 
-  type repo = [ `Github of string * string | `Git of string | `Virtual | `Error of string ]
-  [@@deriving sexp]
+  type repo = [ `Git of string | `Virtual | `Error of string ] [@@deriving sexp]
 
   let equal_repo repo repo' =
     match (repo, repo') with
-    | `Github (user, repo), `Github (user', repo') ->
-        String.equal user user' && String.equal repo repo'
     | `Git s, `Git s' | `Error s, `Error s' -> String.equal s s'
     | `Virtual, `Virtual -> true
-    | (`Github _ | `Git _ | `Virtual | `Error _), _ -> false
+    | (`Git _ | `Virtual | `Error _), _ -> false
 
   let pp_repo = pp_sexp sexp_of_repo
 

--- a/test/test_opam_cmd.ml
+++ b/test/test_opam_cmd.ml
@@ -73,15 +73,11 @@ let test_classify_package =
       ();
     make_test ~name:"github dev-repo" ~package:{ name = "x"; version = None }
       ~dev_repo:"git+https://github.com/user/repo.git" ~archive:""
-      ~expected:(`Github ("user", "repo"), None)
+      ~expected:(`Git "https://github.com/user/repo.git", None)
       ();
     make_test ~name:"guess tag from archive" ~package:{ name = "x"; version = None }
       ~dev_repo:"git+https://github.com/user/repo.git" ~archive:"file-v1.tbz"
-      ~expected:(`Github ("user", "repo"), Some "v1")
-      ();
-    make_test ~name:"unexpected github url" ~package:{ name = "x"; version = None }
-      ~dev_repo:"git+https://github.com/user/repo/oh/my/what/is/this" ~archive:""
-      ~expected:(`Error "weird github url", None)
+      ~expected:(`Git "https://github.com/user/repo.git", Some "v1")
       ();
     make_test ~name:"no host" ~package:{ name = "x"; version = None } ~dev_repo:"nohost.git"
       ~archive:""


### PR DESCRIPTION
Depends on #33, please do not merge before!

As promised I removed the github variant as we were not taking any advantage from it. I believe the code could probably be simplified further as I don't think the `"dev-repo without a host"` error case is necessary but let's keep things simple here. This is just another step towards the duniverse content representation!

Opening as draft until #33 is merged, I'll assign reviewers once it's done!