### PR TITLE
Pass test name to Alcotest.check

### DIFF
--- a/test/test_opam_cmd.ml
+++ b/test/test_opam_cmd.ml
@@ -4,7 +4,7 @@ let test_tag_from_archive =
     let test_name = "tag_from_archive: " ^ name in
     let test_fun () =
       let actual = Duniverse_lib.Opam_cmd.tag_from_archive archive in
-      Alcotest.(check (option string)) archive expected actual
+      Alcotest.(check (option string)) test_name expected actual
     in
     (test_name, `Quick, test_fun)
   in

--- a/test/test_opam_show_result.ml
+++ b/test/test_opam_show_result.ml
@@ -2,11 +2,11 @@ open Duniverse_lib
 
 let test_make =
   let make_test ~name ~input ~expected =
-    let test_name = "make (" ^ name ^ ")" in
+    let test_name = Printf.sprintf "make: %s" name in
     let test_fun () =
       let expected_t = Opam_show_result.from_list expected in
       let actual = Rresult.R.get_ok (Opam_show_result.make input) in
-      Alcotest.(check (module Opam_show_result) name expected_t actual)
+      Alcotest.(check (module Opam_show_result) test_name expected_t actual)
     in
     (test_name, `Quick, test_fun)
   in


### PR DESCRIPTION
This makes it easier to follow the error reports when a lot of tests failed.