### PR TITLE
Improve duniverse representation

### DIFF
--- a/.dockerfiles/opam
+++ b/.dockerfiles/opam
@@ -3,6 +3,7 @@ FROM ocaml/opam2:${DISTRO}
 
 USER opam
 WORKDIR /home/opam/src
+RUN opam switch 4.07
 COPY *.opam .
 RUN opam pin add --no-action duniverse .
 RUN opam update

--- a/cli/init.ml
+++ b/cli/init.ml
@@ -1,9 +1,8 @@
 open Duniverse_lib
 open Duniverse_lib.Types
 
-let compute_opam ~repo ~branch ~explicit_root_packages ~excludes ~pins ~overlay ~remotes =
+let build_config ~local_packages ~branch ~explicit_root_packages ~excludes ~pins ~remotes ~overlay =
   let open Rresult.R.Infix in
-  Opam_cmd.find_local_opam_packages repo >>= fun local_packages ->
   Opam_cmd.choose_root_packages ~explicit_root_packages ~local_packages >>= fun root_packages ->
   let root_packages =
     List.map Opam_cmd.split_opam_name_and_version root_packages |> Opam.sort_uniq
@@ -11,15 +10,20 @@ let compute_opam ~repo ~branch ~explicit_root_packages ~excludes ~pins ~overlay 
   let excludes =
     List.map Opam_cmd.split_opam_name_and_version (local_packages @ excludes) |> Opam.sort_uniq
   in
-  Bos.OS.Dir.tmp ".duniverse-opam-root-%s" >>= fun root ->
   let remotes = overlay :: remotes in
+  Ok {Duniverse.Config.root_packages; excludes; pins; remotes; branch}
+
+let init_tmp_opam ~local_packages ~config:{Duniverse.Config.remotes; pins; _} =
+  let open Rresult.R.Infix in
+  Bos.OS.Dir.tmp ".duniverse-opam-root-%s" >>= fun root ->
   Opam_cmd.init_opam ~root ~remotes () >>= fun () ->
   Exec.(iter (add_opam_dev_pin ~root) pins) >>= fun () ->
   Exec.(iter (add_opam_local_pin ~root) local_packages) >>= fun () ->
-  Opam_cmd.calculate_opam ~root ~root_packages ~pins ~excludes ~remotes ~branch >>= fun opam ->
-  let packages_stats = Opam_cmd.packages_stats opam.packages in
-  Opam_cmd.report_packages_stats packages_stats;
-  Ok opam
+  Ok root
+
+let report_stats ~packages =
+  let packages_stats = Opam_cmd.packages_stats packages in
+  Opam_cmd.report_packages_stats packages_stats
 
 let compute_repos ~opam_entries =
   let open Stdune in
@@ -36,12 +40,17 @@ let compute_repos ~opam_entries =
 let run repo branch explicit_root_packages excludes pins overlay remotes () =
   let open Rresult.R.Infix in
   Common.Logs.app (fun l -> l "Calculating Duniverse on the %a branch" Styled_pp.branch branch);
-  compute_opam ~repo ~branch ~explicit_root_packages ~excludes ~pins ~overlay ~remotes
-  >>= fun opam ->
-  let { Opam.root_packages; excludes; pins; remotes; branch; packages } = opam in
+  Opam_cmd.find_local_opam_packages repo >>= fun local_packages ->
+  build_config ~local_packages ~branch ~explicit_root_packages ~excludes ~pins ~remotes ~overlay
+  >>= fun config ->
+  Common.Logs.app (fun l -> l "Initializing temporary opam switch");
+  init_tmp_opam ~local_packages ~config >>= fun root ->
+  Common.Logs.app (fun l -> l "Resolving dependencies for %a" Fmt.(list ~sep:(unit " ") Styled_pp.package) config.root_packages);
+  Opam_cmd.calculate_opam ~root ~config >>= fun packages ->
+  report_stats ~packages;
   Common.Logs.app (fun l -> l "Calculating Git repositories to vendor");
   compute_repos ~opam_entries:packages >>= fun content ->
-  let duniverse = { Duniverse.root_packages; excludes; pins; remotes; branch; content } in
+  let duniverse = { Duniverse.config; content } in
   let file = Fpath.(repo // Config.duniverse_file) in
   Duniverse.save ~file duniverse >>= fun () ->
   Common.Logs.app (fun l ->

--- a/cli/styled_pp.ml
+++ b/cli/styled_pp.ml
@@ -1,3 +1,5 @@
 let header = Fmt.(styled `Blue (const string "==> "))
 
 let branch = Fmt.(styled `Cyan string)
+
+let package = Fmt.(styled `Yellow Duniverse_lib.Types.Opam.pp_package)

--- a/cli/styled_pp.mli
+++ b/cli/styled_pp.mli
@@ -1,3 +1,5 @@
 val header : unit Fmt.t
 
 val branch : string Fmt.t
+
+val package : Duniverse_lib.Types.Opam.package Fmt.t

--- a/lib/dune_cmd.ml
+++ b/lib/dune_cmd.ml
@@ -16,80 +16,10 @@
 
 open Types
 open Rresult
-open Astring
 
 let pp_header = Fmt.(styled `Blue string)
 
 let header = "==> "
-
-let dune_repo_of_opam opam =
-  let dir = Opam.(opam.package.name) in
-  match opam.Opam.dev_repo with
-  | `Git upstream -> (
-    match opam.Opam.tag with
-    | None ->
-        Exec.git_default_branch ~remote:upstream () >>= fun ref -> Ok { Dune.dir; upstream; ref }
-    | Some ref -> Ok { Dune.dir; upstream; ref } )
-  | _ -> R.error_msg (Fmt.strf "TODO cannot handle %a" Opam.pp_entry opam)
-
-let dedup_git_remotes dunes =
-  (* In the future we should be able to select the subtrees from different git
-     remotes, but for now we error if we require different tags for the same
-     git remote *)
-  let open Dune in
-  Logs.app (fun l ->
-      l "%aDeduplicating the %a git remotes." pp_header header
-        Fmt.(styled `Green int)
-        (List.length dunes) );
-  let by_repo = Hashtbl.create 7 in
-  List.iter
-    (fun dune ->
-      match Hashtbl.find by_repo dune.upstream with
-      | rs -> Hashtbl.replace by_repo dune.upstream (dune :: rs)
-      | exception Not_found -> Hashtbl.add by_repo dune.upstream [ dune ] )
-    dunes;
-  Hashtbl.iter
-    (fun upstream dunes ->
-      match dunes with
-      | [] -> assert false
-      | [ _ ] -> ()
-      | dunes ->
-          let tags = List.map (fun { ref; _ } -> ref) dunes in
-          let uniq_tags = List.sort_uniq String.compare tags in
-          if List.length uniq_tags = 1 then
-            Logs.info (fun l ->
-                l
-                  "%aMultiple entries found for package %a with same tag, so just adding a single \
-                   entry: %s."
-                  pp_header header
-                  Fmt.(styled `Yellow string)
-                  upstream (List.hd uniq_tags) )
-          else
-            let latest_tag = List.sort OpamVersionCompare.compare tags |> List.rev |> List.hd in
-            Logs.app (fun l ->
-                l
-                  "%a@[Multiple entries found for %a with clashing tags @[<1>'%a'@], so selected \
-                   @[<1>'%a'@]%a@]"
-                  pp_header header
-                  Fmt.(styled `Yellow string)
-                  upstream
-                  Fmt.(list ~sep:(unit ",@ ") (styled `Yellow string))
-                  uniq_tags
-                  Fmt.(styled `Green string)
-                  latest_tag Fmt.text
-                  " for use with the opam packages that share the same repo. We may implement \
-                   some fancier subtree resolution to make it possible to support multiple tags \
-                   from the same repository, but not yet." );
-            Hashtbl.replace by_repo upstream
-              (List.map (fun d -> { d with ref = latest_tag }) dunes) )
-    by_repo;
-  (* generate filtered dune list *)
-  Ok
-    (Hashtbl.fold
-       (fun _ v acc ->
-         (List.sort (fun a b -> compare (String.length a.dir) (String.length b.dir)) v |> List.hd)
-         :: acc )
-       by_repo [])
 
 let log_invalid_packages packages =
   let open Opam in
@@ -100,25 +30,19 @@ let log_invalid_packages packages =
       | _ -> () )
     packages
 
-let package_is_valid { Opam.dev_repo; _ } = match dev_repo with `Error _ -> false | _ -> true
-
-let filter_invalid_packages pkgs =
-  Logs.app (fun l ->
-      l "%aEliminating dependencies that are not understood by the Duniverse." pp_header header );
-  log_invalid_packages pkgs;
-  List.filter package_is_valid pkgs
-
 let gen_dune_upstream_branches repo =
-  let ifile = Fpath.(repo // Config.duniverse_file) in
   let open Duniverse in
+  let open Duniverse.Element in
+  let ifile = Fpath.(repo // Config.duniverse_file) in
   load ~file:ifile >>= fun dune ->
-  let repos = dune.repos in
   Exec.iter
-    (fun r ->
-      let open Dune in
-      let output_dir = Fpath.(Config.vendor_dir / r.dir) in
-      Logs.app (fun l ->
-          l "%aPulling sources for %a." pp_header header Fmt.(styled `Cyan Fpath.pp) output_dir );
-      let output_dir = Fpath.(Config.vendor_dir / r.dir) in
-      Exec.git_archive ~output_dir ~remote:r.upstream ~tag:r.ref () )
-    repos
+    (function
+      | Opam _ -> Ok ()
+      | Repo { dir; upstream; ref } ->
+          let output_dir = Fpath.(Config.vendor_dir / dir) in
+          Logs.app (fun l ->
+              l "%aPulling sources for %a." pp_header header Fmt.(styled `Cyan Fpath.pp) output_dir
+          );
+          let output_dir = Fpath.(Config.vendor_dir / dir) in
+          Exec.git_archive ~output_dir ~remote:upstream ~tag:ref () )
+    dune.content

--- a/lib/dune_cmd.ml
+++ b/lib/dune_cmd.ml
@@ -34,7 +34,7 @@ let gen_dune_upstream_branches repo =
   let ifile = Fpath.(repo // Config.duniverse_file) in
   Duniverse.load ~file:ifile >>= fun { deps = { duniverse; _ }; _ } ->
   Exec.iter
-    (fun { Duniverse.Deps.Source.dir; upstream; ref } ->
+    (fun { Duniverse.Deps.Source.dir; upstream; ref; _ } ->
       let output_dir = Fpath.(Config.vendor_dir / dir) in
       Logs.app (fun l ->
           l "%aPulling sources for %a." pp_header header Fmt.(styled `Cyan Fpath.pp) output_dir );

--- a/lib/dune_cmd.ml
+++ b/lib/dune_cmd.ml
@@ -31,17 +31,13 @@ let log_invalid_packages packages =
     packages
 
 let gen_dune_upstream_branches repo =
-  let open Duniverse.Element in
   let ifile = Fpath.(repo // Config.duniverse_file) in
-  Duniverse.load ~file:ifile >>= fun duniverse ->
+  Duniverse.load ~file:ifile >>= fun { deps = { duniverse; _ }; _ } ->
   Exec.iter
-    (function
-      | Opam _ -> Ok ()
-      | Repo { dir; upstream; ref } ->
-          let output_dir = Fpath.(Config.vendor_dir / dir) in
-          Logs.app (fun l ->
-              l "%aPulling sources for %a." pp_header header Fmt.(styled `Cyan Fpath.pp) output_dir
-          );
-          let output_dir = Fpath.(Config.vendor_dir / dir) in
-          Exec.git_archive ~output_dir ~remote:upstream ~tag:ref () )
-    duniverse.content
+    (fun { Duniverse.Deps.Source.dir; upstream; ref } ->
+      let output_dir = Fpath.(Config.vendor_dir / dir) in
+      Logs.app (fun l ->
+          l "%aPulling sources for %a." pp_header header Fmt.(styled `Cyan Fpath.pp) output_dir );
+      let output_dir = Fpath.(Config.vendor_dir / dir) in
+      Exec.git_archive ~output_dir ~remote:upstream ~tag:ref () )
+    duniverse

--- a/lib/dune_cmd.ml
+++ b/lib/dune_cmd.ml
@@ -31,10 +31,9 @@ let log_invalid_packages packages =
     packages
 
 let gen_dune_upstream_branches repo =
-  let open Duniverse in
   let open Duniverse.Element in
   let ifile = Fpath.(repo // Config.duniverse_file) in
-  load ~file:ifile >>= fun dune ->
+  Duniverse.load ~file:ifile >>= fun duniverse ->
   Exec.iter
     (function
       | Opam _ -> Ok ()
@@ -45,4 +44,4 @@ let gen_dune_upstream_branches repo =
           );
           let output_dir = Fpath.(Config.vendor_dir / dir) in
           Exec.git_archive ~output_dir ~remote:upstream ~tag:ref () )
-    dune.content
+    duniverse.content

--- a/lib/duniverse.ml
+++ b/lib/duniverse.ml
@@ -1,13 +1,81 @@
+open Stdune
 open Sexplib.Conv
+
+module Element = struct
+  type t =
+    | Opam of { name : string; version : string option [@default None] [@sexp_drop_default] }
+    | Repo of
+        { dir : string;
+          upstream : string;
+          ref : string [@default "master"] [@sexp_drop_default]
+        }
+  [@@deriving sexp]
+
+  let equal t t' =
+    match (t, t') with
+    | Opam { name; version }, Opam { name = name'; version = version' } ->
+        String.equal name name' && Option.equal String.equal version version'
+    | Repo { dir; upstream; ref }, Repo { dir = dir'; upstream = upstream'; ref = ref' } ->
+        String.equal dir dir' && String.equal upstream upstream' && String.equal ref ref'
+    | (Opam _ | Repo _), _ -> false
+
+  let pp fmt t =
+    let pp_version fmt = function
+      | None -> Format.fprintf fmt "None"
+      | Some v -> Format.fprintf fmt "Some %S" v
+    in
+    match t with
+    | Opam { name; version } ->
+        Format.fprintf fmt "@[<hov 2>{ name = %S;@ version = %a }@]" name pp_version version
+    | Repo { dir; upstream; ref } ->
+        Format.fprintf fmt "@[<hov 2>{ dir = %S;@ upstream = %S;@ ref = %S }@]" dir upstream ref
+
+  let from_opam_entry ~get_default_branch entry =
+    let open Types.Opam in
+    let open Rresult.R.Infix in
+    match entry with
+    | { dev_repo = `Virtual; _ } | { dev_repo = `Error _; _ } -> Ok None
+    | { is_dune = false; package = { name; version }; _ } -> Ok (Some (Opam { name; version }))
+    | { is_dune = true; dev_repo = `Git upstream; tag = Some ref; package = { name; _ } } ->
+        Ok (Some (Repo { dir = name; upstream; ref }))
+    | { is_dune = true; dev_repo = `Git upstream; tag = None; package = { name; _ } } ->
+        get_default_branch upstream >>= fun ref -> Ok (Some (Repo { dir = name; upstream; ref }))
+
+  let dedup_upstream l =
+    let merge_repo t t' =
+      match[@warning "-4"] (t, t') with
+      | Repo { dir; ref; upstream }, Repo { dir = dir'; ref = ref'; _ } ->
+          let min_dir = match String.compare dir dir' with Lt | Eq -> dir | Gt -> dir' in
+          let max_ref =
+            match Ordering.of_int (OpamVersionCompare.compare ref ref') with
+            | Gt | Eq -> ref
+            | Lt -> ref'
+          in
+          Repo { dir = min_dir; ref = max_ref; upstream }
+      | _ -> assert false
+    in
+    let update map upstream t =
+      String.Map.update map upstream ~f:(function
+        | None -> Some t
+        | Some t' -> Some (merge_repo t t') )
+    in
+    let go (opams, upstream_repo_map) t =
+      match t with
+      | Opam _ -> (t :: opams, upstream_repo_map)
+      | Repo { upstream; _ } -> (opams, update upstream_repo_map upstream t)
+    in
+    let opams, upstream_repo_map = List.fold_left l ~init:([], String.Map.empty) ~f:go in
+    let repos = String.Map.values upstream_repo_map in
+    List.rev_append opams repos
+end
 
 type t = {
   root_packages : Types.Opam.package list;
   excludes : Types.Opam.package list;
   pins : Types.Opam.pin list;
-  packages : Types.Opam.entry list;
-  repos : Types.Dune.repo list;
   remotes : string list; [@default []]
-  branch : string [@default "master"]
+  branch : string; [@default "master"]
+  content : Element.t list
 }
 [@@deriving sexp]
 

--- a/lib/duniverse.ml
+++ b/lib/duniverse.ml
@@ -69,12 +69,19 @@ module Element = struct
     List.rev_append opams repos
 end
 
+module Config = struct
+  type t =
+    { root_packages : Types.Opam.package list;
+      excludes : Types.Opam.package list;
+      pins : Types.Opam.pin list;
+      remotes : string list; [@default []]
+      branch : string [@default "master"]
+    }
+  [@@deriving sexp]
+end
+
 type t = {
-  root_packages : Types.Opam.package list;
-  excludes : Types.Opam.package list;
-  pins : Types.Opam.pin list;
-  remotes : string list; [@default []]
-  branch : string; [@default "master"]
+  config : Config.t;
   content : Element.t list
 }
 [@@deriving sexp]

--- a/lib/duniverse.ml
+++ b/lib/duniverse.ml
@@ -8,6 +8,10 @@ module Deps = struct
 
     let equal t t' = String.equal t.name t'.name && Option.equal String.equal t.version t'.version
 
+    let pp fmt = function
+      | { name; version = None } -> Format.fprintf fmt "%s" name
+      | { name; version = Some v } -> Format.fprintf fmt "%s.%s" name v
+
     let raw_pp fmt { name; version } =
       let pp_version fmt = function
         | None -> Format.fprintf fmt "None"

--- a/lib/duniverse.ml
+++ b/lib/duniverse.ml
@@ -13,11 +13,8 @@ module Deps = struct
       | { name; version = Some v } -> Format.fprintf fmt "%s.%s" name v
 
     let raw_pp fmt { name; version } =
-      let pp_version fmt = function
-        | None -> Format.fprintf fmt "None"
-        | Some v -> Format.fprintf fmt "Some %S" v
-      in
-      Format.fprintf fmt "@[<hov 2>{ name = %S;@ version = %a }@]" name pp_version version
+      let open Pp_combinators.Ocaml in
+      Format.fprintf fmt "@[<hov 2>{ name = %S;@ version = %a }@]" name (option string) version
   end
 
   module Source = struct
@@ -90,12 +87,9 @@ module Deps = struct
     && List.equal Source.equal t.duniverse t'.duniverse
 
   let raw_pp fmt t =
-    let pp_list pp_a fmt l =
-      let pp_sep fmt () = Format.fprintf fmt ";@ " in
-      Format.fprintf fmt "@[<hov 2>[@ %a]@]" (Format.pp_print_list ~pp_sep pp_a) l
-    in
-    Format.fprintf fmt "@[<hov 2>{ opamverse = %a;@ duniverse = %a}@]" (pp_list Opam.raw_pp)
-      t.opamverse (pp_list Source.raw_pp) t.duniverse
+    let open Pp_combinators.Ocaml in
+    Format.fprintf fmt "@[<hov 2>{ opamverse = %a;@ duniverse = %a}@]" (list Opam.raw_pp)
+      t.opamverse (list Source.raw_pp) t.duniverse
 
   let from_opam_entries ~get_default_branch entries =
     let open Result.O in

--- a/lib/duniverse.ml
+++ b/lib/duniverse.ml
@@ -77,7 +77,7 @@ module Deps = struct
       String.Map.values aggregated_map
   end
 
-  module One = struct
+  module Classified = struct
     type t = Opam of Opam.t | Source of Source.Package.t
 
     let equal t t' =
@@ -121,10 +121,10 @@ module Deps = struct
 
   let from_opam_entries ~get_default_branch entries =
     let open Result.O in
-    let results = List.map ~f:(One.from_opam_entry ~get_default_branch) entries in
+    let results = List.map ~f:(Classified.from_opam_entry ~get_default_branch) entries in
     Result.List.all results >>= fun dep_options ->
     let deps = List.filter_opt dep_options in
-    let opamverse, source_deps = One.partition_list deps in
+    let opamverse, source_deps = Classified.partition_list deps in
     let duniverse = Source.aggregate_packages source_deps in
     Ok { opamverse; duniverse }
 

--- a/lib/duniverse.mli
+++ b/lib/duniverse.mli
@@ -21,12 +21,19 @@ module Element : sig
   (** [dedup_upstream l] returns [l] with a single repo for any given upstream URL. *)
 end
 
+module Config : sig
+  type t =
+    { root_packages : Types.Opam.package list;
+      excludes : Types.Opam.package list;
+      pins : Types.Opam.pin list;
+      remotes : string list; [@default []]
+      branch : string [@default "master"]
+    }
+  [@@deriving sexp]
+end
+
 type t = {
-  root_packages : Types.Opam.package list;
-  excludes : Types.Opam.package list;
-  pins : Types.Opam.pin list;
-  remotes : string list; [@default []]
-  branch : string; [@default "master"]
+  config : Config.t;
   content : Element.t list
 }
 [@@deriving sexp]

--- a/lib/duniverse.mli
+++ b/lib/duniverse.mli
@@ -1,11 +1,33 @@
+module Element : sig
+  type t =
+    | Opam of { name : string; version : string option [@default None] [@sexp_drop_default] }
+    | Repo of
+        { dir : string;
+          upstream : string;
+          ref : string [@default "master"] [@sexp_drop_default]
+        }
+  [@@deriving sexp]
+
+  val equal : t -> t -> bool
+
+  val pp : t Fmt.t
+
+  val from_opam_entry :
+    get_default_branch:(string -> (string, Rresult.R.msg) result) ->
+    Types.Opam.entry ->
+    (t option, Rresult.R.msg) result
+
+  val dedup_upstream : t list -> t list
+  (** [dedup_upstream l] returns [l] with a single repo for any given upstream URL. *)
+end
+
 type t = {
   root_packages : Types.Opam.package list;
   excludes : Types.Opam.package list;
   pins : Types.Opam.pin list;
-  packages : Types.Opam.entry list;
-  repos : Types.Dune.repo list;
   remotes : string list; [@default []]
-  branch : string [@default "master"]
+  branch : string; [@default "master"]
+  content : Element.t list
 }
 [@@deriving sexp]
 

--- a/lib/duniverse.mli
+++ b/lib/duniverse.mli
@@ -1,42 +1,81 @@
-module Element : sig
-  type t =
-    | Opam of { name : string; version : string option [@default None] [@sexp_drop_default] }
-    | Repo of
-        { dir : string;
-          upstream : string;
-          ref : string [@default "master"] [@sexp_drop_default]
-        }
-  [@@deriving sexp]
+module Deps : sig
+  module Opam : sig
+    (** Type of dependencies to install through opam *)
+    type t = { name : string; version : string option }
+
+    val equal : t -> t -> bool
+  end
+
+  module Source : sig
+    (** Type of dependencies to clone in the duniverse *)
+    type t = { dir : string; upstream : string; ref : string }
+
+    val equal : t -> t -> bool
+
+    (**/**)
+
+    (* Exposed for test purposes only *)
+
+    val raw_pp : t Fmt.t
+
+    val aggregate : t -> t -> t
+
+    val aggregate_list : t list -> t list
+
+    (**/**)
+  end
+
+  (** The type for dependencies of a project. The duniverse and opamverse are complementary,
+      that is a dependency either can be installed by pulling the sources and is in the duniverse
+      or has to be installed through opam and is in the opamverse. *)
+  type t = { opamverse : Opam.t list; duniverse : Source.t list }
 
   val equal : t -> t -> bool
 
-  val pp : t Fmt.t
-
-  val from_opam_entry :
+  val from_opam_entries :
     get_default_branch:(string -> (string, Rresult.R.msg) result) ->
-    Types.Opam.entry ->
-    (t option, Rresult.R.msg) result
+    Types.Opam.entry list ->
+    (t, [ `Msg of string ]) result
+  (** Build opamverse and duniverse from a list of [Types.Opam.entry] values.
+      It filters out virtual packages and packages with unknown dev-repo.  *)
 
-  val dedup_upstream : t list -> t list
-  (** [dedup_upstream l] returns [l] with a single repo for any given upstream URL. *)
+  val count : t -> int
+  (** Returns the total number of dependencies represented by the given [t] value. *)
+
+  (**/**)
+
+  (* Exposed for test purposes only *)
+
+  val raw_pp : t Fmt.t
+
+  module One : sig
+    type t = Opam of Opam.t | Source of Source.t
+
+    val equal : t -> t -> bool
+
+    val raw_pp : t Fmt.t
+
+    val from_opam_entry :
+      get_default_branch:(string -> (string, Rresult.R.msg) result) ->
+      Types.Opam.entry ->
+      (t option, [ `Msg of string ]) result
+  end
+
+  (**/**)
 end
 
 module Config : sig
-  type t =
-    { root_packages : Types.Opam.package list;
-      excludes : Types.Opam.package list;
-      pins : Types.Opam.pin list;
-      remotes : string list; [@default []]
-      branch : string [@default "master"]
-    }
+  type t = {
+    root_packages : Types.Opam.package list;
+    excludes : Types.Opam.package list;
+    pins : Types.Opam.pin list;
+    remotes : string list; [@default []]
+    branch : string [@default "master"]
+  }
   [@@deriving sexp]
 end
 
-type t = {
-  config : Config.t;
-  content : Element.t list
-}
-[@@deriving sexp]
+type t = { config : Config.t; deps : Deps.t } [@@deriving sexp]
 
 val load : file:Fpath.t -> (t, [> `Msg of string ]) result
 

--- a/lib/duniverse.mli
+++ b/lib/duniverse.mli
@@ -10,7 +10,7 @@ module Deps : sig
 
   module Source : sig
     (** Type of dependencies to clone in the duniverse *)
-    type t = { dir : string; upstream : string; ref : string }
+    type t = { dir : string; upstream : string; ref : string; provided_packages : Opam.t list }
 
     val equal : t -> t -> bool
 
@@ -20,9 +20,13 @@ module Deps : sig
 
     val raw_pp : t Fmt.t
 
-    val aggregate : t -> t -> t
+    module Package : sig
+      type t = { opam : Opam.t; upstream : string; ref : string }
+    end
 
-    val aggregate_list : t list -> t list
+    val aggregate : t -> Package.t -> t
+
+    val aggregate_packages : Package.t list -> t list
 
     (**/**)
   end
@@ -51,7 +55,7 @@ module Deps : sig
   val raw_pp : t Fmt.t
 
   module One : sig
-    type t = Opam of Opam.t | Source of Source.t
+    type t = Opam of Opam.t | Source of Source.Package.t
 
     val equal : t -> t -> bool
 

--- a/lib/duniverse.mli
+++ b/lib/duniverse.mli
@@ -4,6 +4,8 @@ module Deps : sig
     type t = { name : string; version : string option }
 
     val equal : t -> t -> bool
+
+    val pp : t Fmt.t
   end
 
   module Source : sig

--- a/lib/duniverse.mli
+++ b/lib/duniverse.mli
@@ -54,7 +54,7 @@ module Deps : sig
 
   val raw_pp : t Fmt.t
 
-  module One : sig
+  module Classified : sig
     type t = Opam of Opam.t | Source of Source.Package.t
 
     val equal : t -> t -> bool

--- a/lib/exec.ml
+++ b/lib/exec.ml
@@ -169,11 +169,11 @@ let add_opam_dev_pin ~root { Opam.pin; url; tag } =
 let add_opam_local_pin ~root package =
   run_and_log Cmd.(opam_cmd ~root "pin" % "add" % "-yn" % (package ^ ".dev") % ".")
 
-let run_opam_install ~yes packages =
+let run_opam_install ~yes opam_deps =
   let packages =
     List.map
-      (fun (pkg : Types.Opam.package) ->
+      (fun (pkg : Duniverse.Deps.Opam.t) ->
         match pkg.version with Some v -> pkg.name ^ "." ^ v | None -> pkg.name )
-      packages
+      opam_deps
   in
   OS.Cmd.run Cmd.(v "opam" % "install" %% on yes (v "-y") %% of_list packages)

--- a/lib/exec.mli
+++ b/lib/exec.mli
@@ -75,6 +75,6 @@ val add_opam_local_pin : root:Fpath.t -> string -> (unit, [> Rresult.R.msg ]) re
 (** [add_opam_local_pin ~root package] pins the package in the current working dir under
     [package ^ ".dev"] in the active switch using [root] as OPAMROOT. *)
 
-val run_opam_install : yes:bool -> Types.Opam.package list -> (unit, [> Rresult.R.msg ]) result
+val run_opam_install : yes:bool -> Duniverse.Deps.Opam.t list -> (unit, [> Rresult.R.msg ]) result
 (** [run_opam_install ~yes packages] launch an opam command to install the given packages. If yes is
     set to true, it doesn't prompt the user for confirmation. *)

--- a/lib/opam.ml
+++ b/lib/opam.ml
@@ -22,11 +22,9 @@ module Dev_repo = struct
     Option.equal equal_vcs vcs vcs' && Uri.equal uri uri'
 
   let pp fmt { vcs; uri } =
-    let pp_opt pp_a fmt = function
-      | None -> Format.fprintf fmt "None"
-      | Some a -> Format.fprintf fmt "Some (%a)" pp_a a
-    in
-    Format.fprintf fmt "@[<hov 2>{ vcs = %a;@ uri = %a }@]" (pp_opt pp_vcs) vcs Uri.pp uri
+    let open Pp_combinators.Ocaml in
+    Format.fprintf fmt "@[<hov 2>{ vcs = %a;@ uri = %a }@]" (option ~brackets:true pp_vcs) vcs
+      Uri.pp uri
 
   let from_string dev_repo =
     match Astring.String.cut ~sep:"+" dev_repo with

--- a/lib/opam_cmd.ml
+++ b/lib/opam_cmd.ml
@@ -306,16 +306,13 @@ let install_incompatible_packages yes repo =
         Config.duniverse_file );
   let file = Fpath.(repo // Config.duniverse_file) in
   Duniverse.load ~file >>= fun { deps = { opamverse; _ }; _ } ->
-  let packages =
-    List.map (fun { Duniverse.Deps.Opam.name; version } -> { Types.Opam.name; version }) opamverse
-  in
-  match packages with
+  match opamverse with
   | [] ->
       Logs.app (fun l -> l "%aGood news! There is no package to install!" pp_header header);
       Ok ()
-  | packages_to_install ->
+  | opamverse ->
       Logs.app (fun l ->
           l "%aInstalling these packages with opam:\n%a" pp_header header
-            Fmt.(list ~sep:sp pp_package)
-            packages_to_install );
-      Exec.run_opam_install ~yes packages_to_install
+            Fmt.(list ~sep:sp Duniverse.Deps.Opam.pp)
+            opamverse );
+      Exec.run_opam_install ~yes opamverse

--- a/lib/opam_cmd.ml
+++ b/lib/opam_cmd.ml
@@ -262,16 +262,6 @@ let report_packages_stats packages_stats =
           Fmt.(styled `Green int)
           packages_stats.total )
 
-let save_opam ~file ~packages_stats opam =
-  save file opam >>= fun () ->
-  Logs.app (fun l ->
-      l "%aWritten %a opam packages to %a." pp_header header
-        Fmt.(styled `Green int)
-        packages_stats.total
-        Fmt.(styled `Cyan Fpath.pp)
-        file );
-  Ok ()
-
 let init_opam ~root ~remotes () =
   let open Types.Opam.Remote in
   let remotes = List.mapi (fun i url -> { name = Fmt.strf "remote%d" i; url }) remotes in

--- a/lib/opam_cmd.ml
+++ b/lib/opam_cmd.ml
@@ -211,7 +211,8 @@ let filter_duniverse_packages ~excludes pkgs =
   in
   fn [] pkgs
 
-let calculate_opam ~root ~root_packages ~excludes ~pins ~branch ~remotes =
+let calculate_opam ~root ~config =
+  let {Duniverse.Config.root_packages; pins; excludes; _ } = config in
   Exec.run_opam_package_deps ~root (List.map string_of_package root_packages)
   >>| List.map split_opam_name_and_version
   >>| List.map (fun p ->
@@ -230,8 +231,7 @@ let calculate_opam ~root ~root_packages ~excludes ~pins ~branch ~remotes =
   Logs.app (fun l ->
       l "%aQuerying local opam switch for their metadata and Dune compatibility." pp_header header
   );
-  get_opam_info ~root ~pins deps >>= filter_duniverse_packages ~excludes >>= fun packages ->
-  Ok { packages; root_packages; excludes; pins; branch; remotes }
+  get_opam_info ~root ~pins deps >>= filter_duniverse_packages ~excludes
 
 type packages_stats = { total : int; dune : int; not_dune : entry list }
 

--- a/lib/pp_combinators.ml
+++ b/lib/pp_combinators.ml
@@ -11,5 +11,5 @@ module Ocaml = struct
     | [ a ] -> Format.fprintf fmt "[%a]" pp_a a
     | l ->
         let pp_sep fmt () = Format.fprintf fmt ";@ " in
-        Format.fprintf fmt "@[<hov 2>[@ %a]@]" (Format.pp_print_list ~pp_sep pp_a) l
+        Format.fprintf fmt "@[<hov 2>[@ %a@ ]@]" (Format.pp_print_list ~pp_sep pp_a) l
 end

--- a/lib/pp_combinators.ml
+++ b/lib/pp_combinators.ml
@@ -1,0 +1,15 @@
+module Ocaml = struct
+  let string fmt s = Format.fprintf fmt "%S" s
+
+  let option ?(brackets = true) pp_a fmt = function
+    | None -> Format.fprintf fmt "None"
+    | Some a when brackets -> Format.fprintf fmt "Some (%a)" pp_a a
+    | Some a -> Format.fprintf fmt "Some %a" pp_a a
+
+  let list pp_a fmt = function
+    | [] -> Format.fprintf fmt "[]"
+    | [ a ] -> Format.fprintf fmt "[%a]" pp_a a
+    | l ->
+        let pp_sep fmt () = Format.fprintf fmt ";@ " in
+        Format.fprintf fmt "@[<hov 2>[@ %a]@]" (Format.pp_print_list ~pp_sep pp_a) l
+end

--- a/lib/pp_combinators.mli
+++ b/lib/pp_combinators.mli
@@ -1,5 +1,5 @@
 module Ocaml : sig
-  (** Combinators to pretty print OCaml values *)
+  (** Combinators to pretty print values as their OCaml representation *)
 
   val string : string Fmt.t
   (** [string fmt s] pretty prints [s], with quotes *)

--- a/lib/pp_combinators.mli
+++ b/lib/pp_combinators.mli
@@ -1,0 +1,16 @@
+module Ocaml : sig
+  (** Combinators to pretty print OCaml values *)
+
+  val string : string Fmt.t
+  (** [string fmt s] pretty prints [s], with quotes *)
+
+  val option : ?brackets:bool -> 'a Fmt.t -> 'a option Fmt.t
+  (** [ocaml_option ~brackets pp_a fmt a_option] pretty prints an ocaml option as
+      ["None"], ["Some %a"] or ["Some (%a)"] if [brackets] is true. It uses [pp_a] to print
+      the value wrapped in the option.
+      [brackets] default to false. *)
+
+  val list : 'a Fmt.t -> 'a list Fmt.t
+  (** [ocaml_list pp_a fmt l] pretty prints l as an ocaml looking list, using [pp_a] to format
+      individual elements. *)
+end

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -53,28 +53,12 @@ module Opam = struct
   }
   [@@deriving sexp]
 
-  type t = {
-    root_packages : package list;
-    excludes : package list;
-    pins : pin list;
-    packages : entry list;
-    remotes : string list; [@default []]
-    branch : string [@default "master"]
-  }
-  [@@deriving sexp]
-
   let pp_package ppf { name; version } =
     match version with None -> Fmt.pf ppf "%s" name | Some v -> Fmt.pf ppf "%s.%s" name v
 
   let string_of_package pkg = Fmt.strf "%a" pp_package pkg
 
   let pp_entry = pp_sexp sexp_of_entry
-
-  let pp = pp_sexp sexp_of_t
-
-  let load file = Persist.load_sexp "opam duniverse" t_of_sexp file
-
-  let save file v = Persist.save_sexp "opam duniverse" sexp_of_t file v
 
   let sort_uniq l = List.sort_uniq (fun a b -> String.compare a.name b.name) l
 end

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -78,22 +78,3 @@ module Opam = struct
 
   let sort_uniq l = List.sort_uniq (fun a b -> String.compare a.name b.name) l
 end
-
-module Dune = struct
-  type repo = {
-    dir : string;
-    upstream : string;
-    ref : string [@default "master"] [@sexp_drop_default]
-  }
-  [@@deriving sexp]
-
-  type t = { repos : repo list } [@@deriving sexp]
-
-  let pp_repo = pp_sexp sexp_of_repo
-
-  let pp = pp_sexp sexp_of_t
-
-  let load file = Persist.load_sexp "git duniverse" t_of_sexp file
-
-  let save file v = Persist.save_sexp "git duniverse" sexp_of_t file v
-end

--- a/test/test_duniverse.ml
+++ b/test/test_duniverse.ml
@@ -151,6 +151,15 @@ module Deps = struct
           ~expected:
             (Ok
                (Some (Source { opam = { name = "y"; version = None }; upstream = "x"; ref = "z" })))
+          ();
+        make_test ~name:"Uses default branch when no tag"
+          ~get_default_branch:(function "x" -> Ok "z" | _ -> assert false)
+          ~entry:
+            (entry_factory ~dev_repo:(`Git "x") ~is_dune:true
+               ~package:{ name = "y"; version = None } ?tag:None ())
+          ~expected:
+            (Ok
+               (Some (Source { opam = { name = "y"; version = None }; upstream = "x"; ref = "z" })))
           ()
       ]
   end

--- a/test/test_duniverse.ml
+++ b/test/test_duniverse.ml
@@ -1,0 +1,80 @@
+module Testable = struct
+  module Element = struct
+    open Duniverse_lib.Duniverse.Element
+
+    let t = Alcotest.testable pp equal
+  end
+
+  module R_msg = struct
+    let t = Alcotest.testable Rresult.R.pp_msg (fun (`Msg s) (`Msg s') -> String.equal s s')
+  end
+end
+
+module Element = struct
+  let test_from_opam_entry =
+    let open Duniverse_lib.Types.Opam in
+    let open Duniverse_lib.Duniverse.Element in
+    let entry_factory ?(package = { name = ""; version = None }) ?(dev_repo = `Virtual) ?tag
+        ?(is_dune = false) () =
+      { package; dev_repo; tag; is_dune }
+    in
+    let make_test ?(get_default_branch = fun _ -> assert false) ~name ~entry ~expected () =
+      let test_name = Printf.sprintf "Element.from_opam_entry: %s" name in
+      let test_fun () =
+        let actual = from_opam_entry ~get_default_branch entry in
+        Alcotest.(check (result (option Testable.Element.t) Testable.R_msg.t))
+          test_name expected actual
+      in
+      (test_name, `Quick, test_fun)
+    in
+    [ make_test ~name:"Virtual" ~entry:(entry_factory ~dev_repo:`Virtual ()) ~expected:(Ok None) ();
+      make_test ~name:"Error"
+        ~entry:(entry_factory ~dev_repo:(`Error "") ())
+        ~expected:(Ok None) ();
+      make_test ~name:"Non dune"
+        ~entry:
+          (entry_factory ~dev_repo:(`Git "") ~is_dune:false
+             ~package:{ name = "x"; version = Some "y" }
+             ())
+        ~expected:(Ok (Some (Opam { name = "x"; version = Some "y" })))
+        ();
+      make_test ~name:"dune"
+        ~entry:
+          (entry_factory ~dev_repo:(`Git "x") ~is_dune:true ~package:{ name = "y"; version = None }
+             ~tag:"z" ())
+        ~expected:(Ok (Some (Repo { dir = "y"; upstream = "x"; ref = "z" })))
+        ()
+    ]
+
+  let test_dedup_upstream =
+    let make_test ~name ~l ~expected () =
+      let test_name = Printf.sprintf "Element.dedup_upstream: %s" name in
+      let test_fun () =
+        let actual = Duniverse_lib.Duniverse.Element.dedup_upstream l in
+        Alcotest.(check (list Testable.Element.t)) test_name expected actual
+      in
+      (test_name, `Quick, test_fun)
+    in
+    [ make_test ~name:"Empty" ~l:[] ~expected:[] ();
+      make_test ~name:"Do not dedup opams"
+        ~l:[ Opam { name = "x"; version = None }; Opam { name = "x"; version = None } ]
+        ~expected:[ Opam { name = "x"; version = None }; Opam { name = "x"; version = None } ]
+        ();
+      make_test ~name:"Dedup upstreams and pick shortest name as dir"
+        ~l:
+          [ Repo { dir = "a"; upstream = "u"; ref = "x" };
+            Repo { dir = "a-lwt"; upstream = "u"; ref = "x" }
+          ]
+        ~expected:[ Repo { dir = "a"; upstream = "u"; ref = "x" } ]
+        ();
+      make_test ~name:"Dedup upstreams and pick latest ref"
+        ~l:
+          [ Repo { dir = "a"; upstream = "u"; ref = "v1.9.0" };
+            Repo { dir = "a-lwt"; upstream = "u"; ref = "v1.10.0" }
+          ]
+        ~expected:[ Repo { dir = "a"; upstream = "u"; ref = "v1.10.0" } ]
+        ()
+    ]
+end
+
+let suite = ("Duniverse", Element.test_from_opam_entry @ Element.test_dedup_upstream)

--- a/test/test_duniverse.ml
+++ b/test/test_duniverse.ml
@@ -10,8 +10,8 @@ module Testable = struct
       let t = Alcotest.testable raw_pp equal
     end
 
-    module One = struct
-      open One
+    module Classified = struct
+      open Classified
 
       let t = Alcotest.testable raw_pp equal
     end
@@ -119,14 +119,14 @@ module Deps = struct
       ]
   end
 
-  module One = struct
+  module Classified = struct
     let test_from_opam_entry =
-      let open Duniverse_lib.Duniverse.Deps.One in
+      let open Duniverse_lib.Duniverse.Deps.Classified in
       let make_test ?(get_default_branch = fun _ -> assert false) ~name ~entry ~expected () =
-        let test_name = Printf.sprintf "Deps.One.from_opam_entry: %s" name in
+        let test_name = Printf.sprintf "Deps.Classified.from_opam_entry: %s" name in
         let test_fun () =
           let actual = from_opam_entry ~get_default_branch entry in
-          Alcotest.(check (result (option Testable.Deps.One.t) Testable.R_msg.t))
+          Alcotest.(check (result (option Testable.Deps.Classified.t) Testable.R_msg.t))
             test_name expected actual
         in
         (test_name, `Quick, test_fun)
@@ -228,5 +228,5 @@ end
 
 let suite =
   ( "Duniverse",
-    Deps.One.test_from_opam_entry @ Deps.Source.test_aggregate @ Deps.Source.test_aggregate_list
-    @ Deps.test_from_opam_entries )
+    Deps.Classified.test_from_opam_entry @ Deps.Source.test_aggregate
+    @ Deps.Source.test_aggregate_list @ Deps.test_from_opam_entries )

--- a/test/test_duniverse.ml
+++ b/test/test_duniverse.ml
@@ -1,8 +1,20 @@
 module Testable = struct
-  module Element = struct
-    open Duniverse_lib.Duniverse.Element
+  module Deps = struct
+    open Duniverse_lib.Duniverse.Deps
 
-    let t = Alcotest.testable pp equal
+    let t = Alcotest.testable raw_pp equal
+
+    module Source = struct
+      open Source
+
+      let t = Alcotest.testable raw_pp equal
+    end
+
+    module One = struct
+      open One
+
+      let t = Alcotest.testable raw_pp equal
+    end
   end
 
   module R_msg = struct
@@ -10,71 +22,139 @@ module Testable = struct
   end
 end
 
-module Element = struct
-  let test_from_opam_entry =
-    let open Duniverse_lib.Types.Opam in
-    let open Duniverse_lib.Duniverse.Element in
-    let entry_factory ?(package = { name = ""; version = None }) ?(dev_repo = `Virtual) ?tag
-        ?(is_dune = false) () =
-      { package; dev_repo; tag; is_dune }
-    in
-    let make_test ?(get_default_branch = fun _ -> assert false) ~name ~entry ~expected () =
-      let test_name = Printf.sprintf "Element.from_opam_entry: %s" name in
-      let test_fun () =
-        let actual = from_opam_entry ~get_default_branch entry in
-        Alcotest.(check (result (option Testable.Element.t) Testable.R_msg.t))
-          test_name expected actual
-      in
-      (test_name, `Quick, test_fun)
-    in
-    [ make_test ~name:"Virtual" ~entry:(entry_factory ~dev_repo:`Virtual ()) ~expected:(Ok None) ();
-      make_test ~name:"Error"
-        ~entry:(entry_factory ~dev_repo:(`Error "") ())
-        ~expected:(Ok None) ();
-      make_test ~name:"Non dune"
-        ~entry:
-          (entry_factory ~dev_repo:(`Git "") ~is_dune:false
-             ~package:{ name = "x"; version = Some "y" }
-             ())
-        ~expected:(Ok (Some (Opam { name = "x"; version = Some "y" })))
-        ();
-      make_test ~name:"dune"
-        ~entry:
-          (entry_factory ~dev_repo:(`Git "x") ~is_dune:true ~package:{ name = "y"; version = None }
-             ~tag:"z" ())
-        ~expected:(Ok (Some (Repo { dir = "y"; upstream = "x"; ref = "z" })))
-        ()
-    ]
+let entry_factory ?(package = { Duniverse_lib.Types.Opam.name = ""; version = None })
+    ?(dev_repo = `Virtual) ?tag ?(is_dune = false) () =
+  { Duniverse_lib.Types.Opam.package; dev_repo; tag; is_dune }
 
-  let test_dedup_upstream =
-    let make_test ~name ~l ~expected () =
-      let test_name = Printf.sprintf "Element.dedup_upstream: %s" name in
+module Deps = struct
+  module Source = struct
+    let test_aggregate =
+      let make_test ~name ~t1 ~t2 ~expected () =
+        let test_name = Printf.sprintf "Deps.Source.aggregate: %s" name in
+        let test_fun () =
+          let actual = Duniverse_lib.Duniverse.Deps.Source.aggregate t1 t2 in
+          Alcotest.(check Testable.Deps.Source.t) test_name expected actual
+        in
+        (test_name, `Quick, test_fun)
+      in
+      [ make_test ~name:"Picks shortest name"
+          ~t1:{ dir = "a"; upstream = "u"; ref = "v1" }
+          ~t2:{ dir = "a-lwt"; upstream = "u"; ref = "v1" }
+          ~expected:{ dir = "a"; upstream = "u"; ref = "v1" }
+          ();
+        make_test ~name:"Picks latest version according to opam"
+          ~t1:{ dir = "a"; upstream = "u"; ref = "v1.9.0" }
+          ~t2:{ dir = "a-lwt"; upstream = "u"; ref = "v1.10.0" }
+          ~expected:{ dir = "a"; upstream = "u"; ref = "v1.10.0" }
+          ()
+      ]
+
+    let test_aggregate_list =
+      let make_test ~name ~l ~expected () =
+        let test_name = Printf.sprintf "Deps.Source.aggregate_list: %s" name in
+        let test_fun () =
+          let actual = Duniverse_lib.Duniverse.Deps.Source.aggregate_list l in
+          Alcotest.(check (list Testable.Deps.Source.t)) test_name expected actual
+        in
+        (test_name, `Quick, test_fun)
+      in
+      [ make_test ~name:"Empty" ~l:[] ~expected:[] ();
+        make_test ~name:"One"
+          ~l:[ { dir = "d"; upstream = "u"; ref = "r" } ]
+          ~expected:[ { dir = "d"; upstream = "u"; ref = "r" } ]
+          ();
+        make_test ~name:"Aggregates per upstream"
+          ~l:
+            [ { dir = "a"; upstream = "u"; ref = "v1" };
+              { dir = "a-lwt"; upstream = "u"; ref = "v1" };
+              { dir = "b"; upstream = "v"; ref = "v1" }
+            ]
+          ~expected:
+            [ { dir = "a"; upstream = "u"; ref = "v1" }; { dir = "b"; upstream = "v"; ref = "v1" } ]
+          ()
+      ]
+  end
+
+  module One = struct
+    let test_from_opam_entry =
+      let open Duniverse_lib.Duniverse.Deps.One in
+      let make_test ?(get_default_branch = fun _ -> assert false) ~name ~entry ~expected () =
+        let test_name = Printf.sprintf "Deps.One.from_opam_entry: %s" name in
+        let test_fun () =
+          let actual = from_opam_entry ~get_default_branch entry in
+          Alcotest.(check (result (option Testable.Deps.One.t) Testable.R_msg.t))
+            test_name expected actual
+        in
+        (test_name, `Quick, test_fun)
+      in
+      [ make_test ~name:"Virtual"
+          ~entry:(entry_factory ~dev_repo:`Virtual ())
+          ~expected:(Ok None) ();
+        make_test ~name:"Error"
+          ~entry:(entry_factory ~dev_repo:(`Error "") ())
+          ~expected:(Ok None) ();
+        make_test ~name:"Non dune"
+          ~entry:
+            (entry_factory ~dev_repo:(`Git "") ~is_dune:false
+               ~package:{ name = "x"; version = Some "y" }
+               ())
+          ~expected:(Ok (Some (Opam { name = "x"; version = Some "y" })))
+          ();
+        make_test ~name:"dune"
+          ~entry:
+            (entry_factory ~dev_repo:(`Git "x") ~is_dune:true
+               ~package:{ name = "y"; version = None } ~tag:"z" ())
+          ~expected:(Ok (Some (Source { dir = "y"; upstream = "x"; ref = "z" })))
+          ()
+      ]
+  end
+
+  let test_from_opam_entries =
+    let make_test ~name ?(get_default_branch = fun _ -> assert false) ~entries ~expected () =
+      let test_name = Printf.sprintf "Deps.from_opam_entries: %s" name in
       let test_fun () =
-        let actual = Duniverse_lib.Duniverse.Element.dedup_upstream l in
-        Alcotest.(check (list Testable.Element.t)) test_name expected actual
+        let actual = Duniverse_lib.Duniverse.Deps.from_opam_entries ~get_default_branch entries in
+        Alcotest.(check (result Testable.Deps.t Testable.R_msg.t)) test_name expected actual
       in
       (test_name, `Quick, test_fun)
     in
-    [ make_test ~name:"Empty" ~l:[] ~expected:[] ();
-      make_test ~name:"Do not dedup opams"
-        ~l:[ Opam { name = "x"; version = None }; Opam { name = "x"; version = None } ]
-        ~expected:[ Opam { name = "x"; version = None }; Opam { name = "x"; version = None } ]
+    [ make_test ~name:"Empty" ~entries:[] ~expected:(Ok { duniverse = []; opamverse = [] }) ();
+      make_test ~name:"Filters virtual"
+        ~entries:[ entry_factory ~dev_repo:`Virtual () ]
+        ~expected:(Ok { duniverse = []; opamverse = [] })
         ();
-      make_test ~name:"Dedup upstreams and pick shortest name as dir"
-        ~l:
-          [ Repo { dir = "a"; upstream = "u"; ref = "x" };
-            Repo { dir = "a-lwt"; upstream = "u"; ref = "x" }
-          ]
-        ~expected:[ Repo { dir = "a"; upstream = "u"; ref = "x" } ]
+      make_test ~name:"Filters error"
+        ~entries:[ entry_factory ~dev_repo:(`Error "msg") () ]
+        ~expected:(Ok { duniverse = []; opamverse = [] })
         ();
-      make_test ~name:"Dedup upstreams and pick latest ref"
-        ~l:
-          [ Repo { dir = "a"; upstream = "u"; ref = "v1.9.0" };
-            Repo { dir = "a-lwt"; upstream = "u"; ref = "v1.10.0" }
+      make_test ~name:"Splits opam and source"
+        ~entries:
+          [ entry_factory
+              ~package:{ name = "x"; version = Some "v" }
+              ~dev_repo:(`Git "g") ~is_dune:false ();
+            entry_factory ~package:{ name = "y"; version = None } ~tag:"w" ~dev_repo:(`Git "h")
+              ~is_dune:true ()
           ]
-        ~expected:[ Repo { dir = "a"; upstream = "u"; ref = "v1.10.0" } ]
+        ~expected:
+          (Ok
+             { duniverse = [ { dir = "y"; upstream = "h"; ref = "w" } ];
+               opamverse = [ { name = "x"; version = Some "v" } ]
+             })
+        ();
+      make_test ~name:"Aggregates repos"
+        ~entries:
+          [ entry_factory ~package:{ name = "y"; version = None } ~tag:"w" ~dev_repo:(`Git "h")
+              ~is_dune:true ();
+            entry_factory
+              ~package:{ name = "y-lwt"; version = None }
+              ~tag:"w" ~dev_repo:(`Git "h") ~is_dune:true ()
+          ]
+        ~expected:(Ok { duniverse = [ { dir = "y"; upstream = "h"; ref = "w" } ]; opamverse = [] })
         ()
     ]
 end
 
-let suite = ("Duniverse", Element.test_from_opam_entry @ Element.test_dedup_upstream)
+let suite =
+  ( "Duniverse",
+    Deps.One.test_from_opam_entry @ Deps.Source.test_aggregate @ Deps.Source.test_aggregate_list
+    @ Deps.test_from_opam_entries )

--- a/test/test_duniverse.mli
+++ b/test/test_duniverse.mli
@@ -1,0 +1,1 @@
+val suite : string * unit Alcotest.test_case list

--- a/test/test_duniverse_lib.ml
+++ b/test/test_duniverse_lib.ml
@@ -1,3 +1,8 @@
 let () =
   Alcotest.run "Duniverse"
-    [ Test_opam_cmd.suite; Test_uri_utils.suite; Test_opam.suite; Test_opam_show_result.suite ]
+    [ Test_opam_cmd.suite;
+      Test_uri_utils.suite;
+      Test_opam.suite;
+      Test_duniverse.suite;
+      Test_opam_show_result.suite
+    ]

--- a/test/test_duniverse_lib.ml
+++ b/test/test_duniverse_lib.ml
@@ -1,7 +1,3 @@
 let () =
   Alcotest.run "Duniverse"
-    [ Test_opam_cmd.suite;
-      Test_uri_utils.suite;
-      Test_opam.suite;
-      ("Opam_show_result", Test_opam_show_result.test_make)
-    ]
+    [ Test_opam_cmd.suite; Test_uri_utils.suite; Test_opam.suite; Test_opam_show_result.suite ]

--- a/test/test_opam_show_result.ml
+++ b/test/test_opam_show_result.ml
@@ -27,3 +27,5 @@ let test_make =
       ~input:[ "name       test2"; "url:   bonjour.com"; "name   test"; {|field2   ["salut"]|} ]
       ~expected:[ ("test", "field2", {|["salut"]|}); ("test2", "url:", "bonjour.com") ]
   ]
+
+let suite = ("Opam_show_result", test_make)

--- a/test/test_opam_show_result.mli
+++ b/test/test_opam_show_result.mli
@@ -1,1 +1,1 @@
-val test_make : unit Alcotest.test_case list
+val suite : string * unit Alcotest.test_case list


### PR DESCRIPTION
Depends on #38 so creating as draft.

This PR aims at using a better internal representation of the `duniverse` so that the "hard" part is building and there's no need for complex logic when manipulating it afterwards.

In other word once `duniverse init` has written the `dune-get`, rest is easy.

It's a pretty big PR compared to what we had so far so I'll try to summarize the changes here a bit. This is a refactoring and shouldn't result in a change of behaviour of the tool (with one exception that I'll bring up later).

The duniverse is now split in two parts: the configuration and the dependencies.

The configuration is just the set of parameters we use to resolve the dependencies during the `init` command and that we might eventually reuse elsewhere, especially if we need to run opam operations.

The dependencies are as the name suggest the set of dependencies for the root packages of your project. It is now split in two complementary parts: a `duniverse` which contains everything we can clone and build from sources in the `duniverse/` folder and an `opamverse` which contains all the packages we have to install through opam.
We didn't lose any information compared to what we use to have since the new representation contains the list of provided opam packages for each source repository in the `duniverse`.

We lost the log that was warning users that conflicting tag/branch were found for a given repo and telling them which one we were picking but it should be fairly easy to bring back if we really want it, which I assume we kind of do but wanted your opinion.

There's been a bunch of small refactors on the way, a lot of new tests, a bit of documentation and so on. It's just a first step but I think overall it's a huge improvement and should make it much easier to work on new features and improve the tool from there.