### PR TITLE
Improve dev repo parsing

### DIFF
--- a/test/test_opam.ml
+++ b/test/test_opam.ml
@@ -27,6 +27,9 @@ module Dev_repo = struct
         ();
       make_test ~dev_repo:"hg+https://host.com/repo"
         ~expected:{ vcs = Some (Other "hg"); uri = Uri.of_string "https://host.com/repo" }
+        ();
+      make_test ~dev_repo:"git://github.com/lpw25/async_graphics"
+        ~expected:{ vcs = Some Git; uri = Uri.of_string "git://github.com/lpw25/async_graphics" }
         ()
     ]
 end


### PR DESCRIPTION
Previously URIs such as `git://github.com/lpw25/async_graphics` weren't recognized as git URIs, leading to such dependencies to be skipped by duniverse.

This PR adds support for such URIs.