### PR TITLE
Rely less on dev-repo field (e.g. for opam pins)

### DIFF
--- a/test/test_opam_cmd.ml
+++ b/test/test_opam_cmd.ml
@@ -48,10 +48,10 @@ let test_tag_from_archive =
   ]
 
 let test_classify_package =
-  let make_test ~name ~package ?(dev_repo = "dummy-dev-repo") ?archive ?(pins = []) ~expected () =
+  let make_test ~name ~package ?(dev_repo = "dummy-dev-repo") ?archive ~expected () =
     let test_name = Printf.sprintf "classify_package: %s" name in
     let test_fun () =
-      let actual = Duniverse_lib.Opam_cmd.classify_package ~package ~dev_repo ~archive ~pins () in
+      let actual = Duniverse_lib.Opam_cmd.classify_package ~package ~dev_repo ~archive () in
       Alcotest.(check (pair Testable.opam_repo (option string))) test_name expected actual
     in
     (test_name, `Quick, test_fun)

--- a/test/test_opam_cmd.ml
+++ b/test/test_opam_cmd.ml
@@ -90,7 +90,16 @@ let test_classify_package =
     make_test ~name:"wrong vcs" ~package:{ name = "x"; version = None }
       ~dev_repo:"hg+https://host.com/some-repo" ~archive:""
       ~expected:(`Error "dev-repo doesn't use git as a VCS", None)
+      ();
+    make_test ~name:"use url.src when possible" ~package:{ name = "x"; version = None }
+      ~dev_repo:"git+https://host.com/some-repo.git" ~archive:"git+https://host.com/some-fork.git#dev"
+      ~expected:(`Git "https://host.com/some-fork.git", Some "dev")
+      ();
+    make_test ~name:"fallback to dev_repo" ~package:{ name = "x"; version = None }
+      ~dev_repo:"git+https://host.com/some-repo.git" ~archive:"https://github.com/user/repo/releases/download/v1.2.3/archive.tbz"
+      ~expected:(`Git "https://host.com/some-repo.git", Some "v1.2.3")
       ()
   ]
+
 
 let suite = ("Opam_cmd", test_tag_from_archive @ test_classify_package)

--- a/test/test_opam_cmd.ml
+++ b/test/test_opam_cmd.ml
@@ -92,14 +92,15 @@ let test_classify_package =
       ~expected:(`Error "dev-repo doesn't use git as a VCS", None)
       ();
     make_test ~name:"use url.src when possible" ~package:{ name = "x"; version = None }
-      ~dev_repo:"git+https://host.com/some-repo.git" ~archive:"git+https://host.com/some-fork.git#dev"
+      ~dev_repo:"git+https://host.com/some-repo.git"
+      ~archive:"git+https://host.com/some-fork.git#dev"
       ~expected:(`Git "https://host.com/some-fork.git", Some "dev")
       ();
     make_test ~name:"fallback to dev_repo" ~package:{ name = "x"; version = None }
-      ~dev_repo:"git+https://host.com/some-repo.git" ~archive:"https://github.com/user/repo/releases/download/v1.2.3/archive.tbz"
+      ~dev_repo:"git+https://host.com/some-repo.git"
+      ~archive:"https://github.com/user/repo/releases/download/v1.2.3/archive.tbz"
       ~expected:(`Git "https://host.com/some-repo.git", Some "v1.2.3")
       ()
   ]
-
 
 let suite = ("Opam_cmd", test_tag_from_archive @ test_classify_package)


### PR DESCRIPTION
In an attempt to solve https://github.com/avsm/duniverse/issues/37
Basically it tries to parse url.src as a dev-repo field before having to fallback on the actual dev-repo field.