### PR TITLE
Fix git ref resolution with packed-refs

### DIFF
--- a/cli/pull.ml
+++ b/cli/pull.ml
@@ -65,9 +65,9 @@ let mark_duniverse_content_as_vendored ~duniverse_dir =
   Ok ()
 
 let warn_about_head_commit ~ref ~commit () =
-  Common.Logs.app (fun l ->
+  Logs.info (fun l ->
       l "%a is not the HEAD commit for %a anymore" Styled_pp.commit commit Styled_pp.branch ref );
-  Common.Logs.app (fun l -> l "You might want to consider running 'duniverse update'");
+  Logs.info (fun l -> l "You might want to consider running 'duniverse update'");
   ()
 
 let checkout_if_needed ~head_commit ~output_dir ~ref ~commit () =

--- a/lib/exec.ml
+++ b/lib/exec.ml
@@ -118,12 +118,11 @@ let git_add_all_and_commit ~repo ~message () =
 let git_merge ?(args = Cmd.empty) ~from ~repo () = run_git ~repo Cmd.(v "merge" %% args % from)
 
 let git_resolve ~remote ~ref =
-  run_and_log_l Cmd.(v "git" % "ls-remote" % remote % ref) >>= function
-  | [ line ] -> Git.parse_ls_remote_line line >>= fun (commit, _) -> Ok { Git.Ref.t = ref; commit }
-  | [] -> Rresult.R.error_msgf "No %a ref for %s" Git.Ref.pp ref remote
-  | _ ->
-      Rresult.R.error_msgf "Ref %a is pointing to more than one commit for %s" Git.Ref.pp ref
-        remote
+  run_and_log_l Cmd.(v "git" % "ls-remote" % remote %% Git.Ls_remote.ref_arg ref) >>= fun output ->
+  match Git.Ls_remote.commit_pointed_by ~ref output with
+  | Ok commit -> Ok { Git.Ref.t = ref; commit }
+  | Error `No_such_ref -> Rresult.R.error_msgf "No %a ref for %s" Git.Ref.pp ref remote
+  | Error (`Msg _) as err -> err
 
 let opam_cmd ~root sub_cmd =
   let open Cmd in

--- a/lib/exec.ml
+++ b/lib/exec.ml
@@ -122,6 +122,9 @@ let git_resolve ~remote ~ref =
   match Git.Ls_remote.commit_pointed_by ~ref output with
   | Ok commit -> Ok { Git.Ref.t = ref; commit }
   | Error `No_such_ref -> Rresult.R.error_msgf "No %a ref for %s" Git.Ref.pp ref remote
+  | Error `Points_to_several_commits ->
+      Rresult.R.error_msgf "Ref %a is pointing to more than one commit for %s" Git.Ref.pp ref
+        remote
   | Error (`Msg _) as err -> err
 
 let opam_cmd ~root sub_cmd =

--- a/lib/exec.ml
+++ b/lib/exec.ml
@@ -122,9 +122,8 @@ let git_resolve ~remote ~ref =
   match Git.Ls_remote.commit_pointed_by ~ref output with
   | Ok commit -> Ok { Git.Ref.t = ref; commit }
   | Error `No_such_ref -> Rresult.R.error_msgf "No %a ref for %s" Git.Ref.pp ref remote
-  | Error `Points_to_several_commits ->
-      Rresult.R.error_msgf "Ref %a is pointing to more than one commit for %s" Git.Ref.pp ref
-        remote
+  | Error `Multiple_such_refs ->
+      Rresult.R.error_msgf "Multiple refs share the name %a on the remote %s" Git.Ref.pp ref remote
   | Error (`Msg _) as err -> err
 
 let opam_cmd ~root sub_cmd =

--- a/lib/git.ml
+++ b/lib/git.ml
@@ -33,7 +33,7 @@ module Ls_remote = struct
       | { maybe_packed = None; _ }, (commit, full_ref) :: tl when is_ref full_ref ->
           go { acc with maybe_packed = Some commit } tl
       | _, (_, full_ref) :: _ when is_non_packed_ref full_ref || is_ref full_ref ->
-          Error `Points_to_several_commits
+          Error `Multiple_such_refs
       | _, _ :: tl -> go acc tl
     in
     Result.List.map ~f:parse_output_line output_lines >>= fun parsed_lines ->

--- a/lib/git.ml
+++ b/lib/git.ml
@@ -1,10 +1,30 @@
 open Stdune
 open Sexplib.Conv
 
-let parse_ls_remote_line s =
-  match String.extract_blank_separated_words s with
-  | [ commit; ref ] -> Ok (commit, ref)
-  | _ -> Error (`Msg (Printf.sprintf "Invalid git ls-remote output line: %S" s))
+module Ls_remote = struct
+  let non_packed_suffix = "^{}"
+
+  let ref_arg ref = Bos.Cmd.(v ref % (ref ^ non_packed_suffix))
+
+  let parse_output_line s =
+    match String.extract_blank_separated_words s with
+    | [ commit; ref ] -> Ok (commit, ref)
+    | _ -> Error (`Msg (Printf.sprintf "Invalid git ls-remote output line: %S" s))
+
+  let commit_pointed_by ~ref output_lines =
+    let open Result.O in
+    let non_packed = ref ^ non_packed_suffix in
+    let is_ref full_ref = String.is_suffix ~suffix:ref full_ref in
+    let is_non_packed_ref full_ref = String.is_suffix ~suffix:non_packed full_ref in
+    let rec go acc = function
+      | [] -> acc
+      | (commit, full_ref) :: _ when is_non_packed_ref full_ref -> Ok commit
+      | (commit, full_ref) :: tl when is_ref full_ref -> go (Ok commit) tl
+      | _ :: tl -> go acc tl
+    in
+    Result.List.map ~f:parse_output_line output_lines >>= fun parsed_lines ->
+    go (Error `No_such_ref) parsed_lines
+end
 
 module Ref = struct
   type t = string [@@deriving sexp]

--- a/lib/git.ml
+++ b/lib/git.ml
@@ -11,19 +11,34 @@ module Ls_remote = struct
     | [ commit; ref ] -> Ok (commit, ref)
     | _ -> Error (`Msg (Printf.sprintf "Invalid git ls-remote output line: %S" s))
 
+  type search_result = { maybe_packed : string option; not_packed : string option }
+
+  let interpret_search_result sr =
+    match sr with
+    | { maybe_packed = None; not_packed = None } -> Error `No_such_ref
+    | { maybe_packed = Some commit; not_packed = None }
+    | { maybe_packed = _; not_packed = Some commit } ->
+        Ok commit
+
   let commit_pointed_by ~ref output_lines =
     let open Result.O in
     let non_packed = ref ^ non_packed_suffix in
     let is_ref full_ref = String.is_suffix ~suffix:ref full_ref in
     let is_non_packed_ref full_ref = String.is_suffix ~suffix:non_packed full_ref in
-    let rec go acc = function
-      | [] -> acc
-      | (commit, full_ref) :: _ when is_non_packed_ref full_ref -> Ok commit
-      | (commit, full_ref) :: tl when is_ref full_ref -> go (Ok commit) tl
-      | _ :: tl -> go acc tl
+    let rec go acc lines =
+      match (acc, lines) with
+      | _, [] -> Ok acc
+      | { not_packed = None; _ }, (commit, full_ref) :: tl when is_non_packed_ref full_ref ->
+          go { acc with not_packed = Some commit } tl
+      | { maybe_packed = None; _ }, (commit, full_ref) :: tl when is_ref full_ref ->
+          go { acc with maybe_packed = Some commit } tl
+      | _, (_, full_ref) :: _ when is_non_packed_ref full_ref || is_ref full_ref ->
+          Error `Points_to_several_commits
+      | _, _ :: tl -> go acc tl
     in
     Result.List.map ~f:parse_output_line output_lines >>= fun parsed_lines ->
-    go (Error `No_such_ref) parsed_lines
+    go { maybe_packed = None; not_packed = None } parsed_lines >>= fun search_result ->
+    interpret_search_result search_result
 end
 
 module Ref = struct

--- a/lib/git.mli
+++ b/lib/git.mli
@@ -1,6 +1,24 @@
-val parse_ls_remote_line : string -> (string * string, Rresult.R.msg) result
-(** Parse the given git ls-remote output line and return the pair
-    [(commit_hash, fully_qualified_ref)]. *)
+module Ls_remote : sig
+  val ref_arg : string -> Bos.Cmd.t
+  (** [ref_arg ref] returns the CLI arguments to pass to git ls-remote
+      to find the commit pointed by [ref] even the target repository uses packed-refs. *)
+
+  val commit_pointed_by :
+    ref:string -> string list -> (string, [> `No_such_ref | `Msg of string ]) result
+  (** [commit_pointed_by ~ref ls_remote_output] parses the output from git ls-remote
+      and returns the commit pointed by [ref] if it can be determined from it.
+      It will work even if the repo uses packed-refs. *)
+
+  (**/**)
+
+  (* Exposed for test purposes only *)
+
+  val parse_output_line : string -> (string * string, Rresult.R.msg) result
+  (** Parse the given git ls-remote output line and return the pair
+      [(commit_hash, fully_qualified_ref)]. *)
+
+  (**/**)
+end
 
 module Ref : sig
   type t = string

--- a/lib/git.mli
+++ b/lib/git.mli
@@ -1,6 +1,6 @@
 val parse_ls_remote_line : string -> (string * string, Rresult.R.msg) result
 (** Parse the given git ls-remote output line and return the pair
-    [(commit_hash, full_qualified_ref)]. *)
+    [(commit_hash, fully_qualified_ref)]. *)
 
 module Ref : sig
   type t = string

--- a/lib/git.mli
+++ b/lib/git.mli
@@ -6,7 +6,7 @@ module Ls_remote : sig
   val commit_pointed_by :
     ref:string ->
     string list ->
-    (string, [> `No_such_ref | `Points_to_several_commits | `Msg of string ]) result
+    (string, [> `No_such_ref | `Multiple_such_refs | `Msg of string ]) result
   (** [commit_pointed_by ~ref ls_remote_output] parses the output from git ls-remote
       and returns the commit pointed by [ref] if it can be determined from it.
       It will work even if the repo uses packed-refs. *)

--- a/lib/git.mli
+++ b/lib/git.mli
@@ -4,7 +4,9 @@ module Ls_remote : sig
       to find the commit pointed by [ref] even the target repository uses packed-refs. *)
 
   val commit_pointed_by :
-    ref:string -> string list -> (string, [> `No_such_ref | `Msg of string ]) result
+    ref:string ->
+    string list ->
+    (string, [> `No_such_ref | `Points_to_several_commits | `Msg of string ]) result
   (** [commit_pointed_by ~ref ls_remote_output] parses the output from git ls-remote
       and returns the commit pointed by [ref] if it can be determined from it.
       It will work even if the repo uses packed-refs. *)

--- a/test/test_git.ml
+++ b/test/test_git.ml
@@ -1,17 +1,66 @@
-let test_parse_ls_remote_line =
-  let make_test ~name ~line ~expected () =
-    let test_name = Printf.sprintf "parse_ls_remote_line: %s" name in
-    let test_fun () =
-      let actual = Duniverse_lib.Git.parse_ls_remote_line line in
-      Alcotest.(check (result (pair string string) Testable.r_msg)) test_name expected actual
-    in
-    (test_name, `Quick, test_fun)
-  in
-  [ make_test ~name:"Ok" ~line:"12ab  refs/tags/v1" ~expected:(Ok ("12ab", "refs/tags/v1")) ();
-    make_test ~name:"Error" ~line:"12ab  refs/tags/v1 something"
-      ~expected:
-        (Error (`Msg "Invalid git ls-remote output line: \"12ab  refs/tags/v1 something\""))
-      ()
-  ]
+module Testable = struct
+  include Testable
 
-let suite = ("Git", test_parse_ls_remote_line)
+  let commit_pointed_by_error =
+    let equal err err' =
+      match (err, err') with
+      | `No_such_ref, `No_such_ref -> true
+      | `Msg s, `Msg s' -> String.equal s s'
+      | _ -> false
+    in
+    let pp fmt = function
+      | `Msg _ as m -> Rresult.R.pp_msg fmt m
+      | `No_such_ref -> Format.pp_print_string fmt "`No_such_ref"
+    in
+    Alcotest.testable pp equal
+end
+
+module Ls_remote = struct
+  let test_parse_output_line =
+    let make_test ~name ~line ~expected () =
+      let test_name = Printf.sprintf "Ls_remote.parse_output_line: %s" name in
+      let test_fun () =
+        let actual = Duniverse_lib.Git.Ls_remote.parse_output_line line in
+        Alcotest.(check (result (pair string string) Testable.r_msg)) test_name expected actual
+      in
+      (test_name, `Quick, test_fun)
+    in
+    [ make_test ~name:"Ok" ~line:"12ab  refs/tags/v1" ~expected:(Ok ("12ab", "refs/tags/v1")) ();
+      make_test ~name:"Error" ~line:"12ab  refs/tags/v1 something"
+        ~expected:
+          (Error (`Msg "Invalid git ls-remote output line: \"12ab  refs/tags/v1 something\""))
+        ()
+    ]
+
+  let test_commit_pointed_by =
+    let make_test ~name ~ref ~lines ~expected () =
+      let test_name = Printf.sprintf "Ls_remote.commit_pointed_by: %s" name in
+      let test_fun () =
+        let actual = Duniverse_lib.Git.Ls_remote.commit_pointed_by ~ref lines in
+        Alcotest.(check (result string Testable.commit_pointed_by_error)) test_name expected actual
+      in
+      (test_name, `Quick, test_fun)
+    in
+    [ make_test ~name:"Empty output" ~ref:"v1" ~lines:[] ~expected:(Error `No_such_ref) ();
+      make_test ~name:"Not in output" ~ref:"v1" ~lines:[ "0001    refs/heads/master" ]
+        ~expected:(Error `No_such_ref)
+        ();
+      make_test ~name:"Invalid output" ~ref:"v1" ~lines:[ "invalid-output" ]
+        ~expected:(Error (`Msg "Invalid git ls-remote output line: \"invalid-output\""))
+        ();
+      make_test ~name:"Regular repo" ~ref:"v1"
+        ~lines:[ "0001   refs/heads/master"; "0002   refs/tags/v1" ]
+        ~expected:(Ok "0002") ();
+      make_test ~name:"Repo with packed refs" ~ref:"v1"
+        ~lines:[ "0001   refs/heads/master"; "0002   refs/tags/v1"; "0003   refs/tags/v1^{}" ]
+        ~expected:(Ok "0003") ();
+      make_test ~name:"Order doesn't matter" ~ref:"v1"
+        ~lines:[ "0003   refs/tags/v1^{}"; "0001   refs/heads/master"; "0002   refs/tags/v1" ]
+        ~expected:(Ok "0003") ();
+      make_test ~name:"Works with branches" ~ref:"some-branch"
+        ~lines:[ "0001    refs/heads/master"; "0002   refs/heads/some-branch" ]
+        ~expected:(Ok "0002") ()
+    ]
+end
+
+let suite = ("Git", Ls_remote.test_parse_output_line @ Ls_remote.test_commit_pointed_by)

--- a/test/test_git.ml
+++ b/test/test_git.ml
@@ -5,14 +5,14 @@ module Testable = struct
     let equal err err' =
       match (err, err') with
       | `No_such_ref, `No_such_ref -> true
-      | `Points_to_several_commits, `Points_to_several_commits -> true
+      | `Multiple_such_refs, `Multiple_such_refs -> true
       | `Msg s, `Msg s' -> String.equal s s'
       | _ -> false
     in
     let pp fmt = function
       | `Msg _ as m -> Rresult.R.pp_msg fmt m
       | `No_such_ref -> Format.pp_print_string fmt "`No_such_ref"
-      | `Points_to_several_commits -> Format.pp_print_string fmt "Points_to_several_commits"
+      | `Multiple_such_refs -> Format.pp_print_string fmt "Multiple_such_refs"
     in
     Alcotest.testable pp equal
 end
@@ -64,7 +64,7 @@ module Ls_remote = struct
         ~expected:(Ok "0002") ();
       make_test ~name:"Points to several commits" ~ref:"abc"
         ~lines:[ "001   refs/heads/abc"; "002   refs/tags/abc" ]
-        ~expected:(Error `Points_to_several_commits)
+        ~expected:(Error `Multiple_such_refs)
         ();
       make_test ~name:"Points to several commits (with packed-refs)" ~ref:"abc"
         ~lines:
@@ -73,7 +73,7 @@ module Ls_remote = struct
             "003   refs/tags/abc";
             "004   refs/tags/abc^{}"
           ]
-        ~expected:(Error `Points_to_several_commits)
+        ~expected:(Error `Multiple_such_refs)
         ()
     ]
 end


### PR DESCRIPTION
This fixes an issue with a log about the registered commit not being the head commit for the ref anymore. It used to appear when the repo had packed-refs.

The bug is fixed and that log is now info level since there are valid use case for sticking to an older commit.