### PR TITLE
Use threads to speed up init and pull

### DIFF
--- a/cli/pull.ml
+++ b/cli/pull.ml
@@ -70,7 +70,7 @@ let warn_about_head_commit ~ref ~commit () =
   Common.Logs.app (fun l -> l "You might want to consider running 'duniverse update'");
   ()
 
-let checkout_if_needed ~head_commit ~output_dir ~ref ~commit () =
+let checkout_if_needed ~head_commit ~output_dir ~ref ~commit ~dir () =
   let open Result.O in
   if String.equal commit head_commit then Ok ()
   else (
@@ -78,7 +78,7 @@ let checkout_if_needed ~head_commit ~output_dir ~ref ~commit () =
     Exec.git_unshallow ~repo:output_dir () >>= fun () ->
     match Exec.git_checkout ~repo:output_dir commit with
     | Ok () -> Ok ()
-    | Error (`Msg _) -> Error `Commit_is_gone )
+    | Error (`Msg _) -> Error (`Commit_is_gone dir) )
 
 let pull ~duniverse_dir src_dep =
   let open Result.O in
@@ -89,7 +89,7 @@ let pull ~duniverse_dir src_dep =
   Bos.OS.Dir.delete ~recurse:true output_dir >>= fun () ->
   Exec.git_shallow_clone ~output_dir ~remote:upstream ~ref () >>= fun () ->
   Exec.git_rev_parse ~repo:output_dir ~ref:"HEAD" () >>= fun head_commit ->
-  checkout_if_needed ~head_commit ~output_dir ~ref ~commit () >>= fun () ->
+  checkout_if_needed ~head_commit ~output_dir ~ref ~commit ~dir () >>= fun () ->
   Bos.OS.Dir.delete ~must_exist:true ~recurse:true Fpath.(output_dir / ".git") >>= fun () ->
   Bos.OS.Dir.delete ~recurse:true Fpath.(output_dir // Config.vendor_dir)
 
@@ -108,14 +108,12 @@ let report_commit_is_gone_repos repos =
 
 let pull_source_dependencies ~duniverse_dir src_deps =
   let open Result.O in
-  let open Duniverse.Deps.Source in
-  Result.List.fold_left ~init:[]
-    ~f:(fun acc src_dep ->
-      match pull ~duniverse_dir src_dep with
-      | Ok () -> Ok acc
-      | Error `Commit_is_gone -> Ok (src_dep.dir :: acc)
-      | Error (`Msg _ as err) -> Error (err :> [> `Msg of string ]) )
-    src_deps
+  Parallel.map ~f:(pull ~duniverse_dir) src_deps
+  |> Result.List.fold_left ~init:[] ~f:(fun acc res ->
+         match res with
+         | Ok () -> Ok acc
+         | Error (`Commit_is_gone dir) -> Ok (dir :: acc)
+         | Error (`Msg _ as err) -> Error (err :> [> `Msg of string ]) )
   >>= function
   | [] ->
       let total = List.length src_deps in

--- a/lib/dune
+++ b/lib/dune
@@ -1,6 +1,6 @@
 (library
  (name duniverse_lib)
- (libraries stdune bos fmt logs opam-core opam-file-format rresult sexplib
-   uri)
+ (libraries stdune bos fmt threads logs opam-core opam-file-format rresult
+   sexplib uri)
  (preprocess
   (pps ppx_sexp_conv)))

--- a/lib/duniverse.ml
+++ b/lib/duniverse.ml
@@ -152,8 +152,8 @@ module Deps = struct
 
   let resolve ~resolve_ref t =
     let open Result.O in
-    Result.List.map ~f:(Source.resolve ~resolve_ref) t.duniverse >>= fun duniverse ->
-    Ok { t with duniverse }
+    Parallel.map ~f:(Source.resolve ~resolve_ref) t.duniverse |> Result.List.all
+    >>= fun duniverse -> Ok { t with duniverse }
 end
 
 module Config = struct

--- a/lib/parallel.ml
+++ b/lib/parallel.ml
@@ -1,0 +1,31 @@
+open Stdune
+
+let n_threads = 24
+
+let map ~f l =
+  let queue = ref l in
+  let queue_lock = Mutex.create () in
+  let rec worker result =
+    Mutex.lock queue_lock;
+    let hd =
+      match !queue with
+      | [] -> None
+      | hd :: tl ->
+          queue := tl;
+          Some hd
+    in
+    Mutex.unlock queue_lock;
+    match hd with
+    | None -> ()
+    | Some hd ->
+        result := f hd :: !result;
+        worker result
+  in
+  let threads, results =
+    List.init n_threads ~f:(fun _ ->
+        let result = ref [] in
+        (Thread.create worker result, result) )
+    |> List.split
+  in
+  List.iter ~f:Thread.join threads;
+  List.map ~f:( ! ) results |> List.flatten

--- a/lib/parallel.mli
+++ b/lib/parallel.mli
@@ -1,0 +1,3 @@
+val map : f:('a -> 'b) -> 'a list -> 'b list
+(** [map ~f lst] Applies f to each element of lst and returns the resulting list.
+    This is done concurrently using threads, so f needs to be thread-safe. *)

--- a/lib/parallel.mli
+++ b/lib/parallel.mli
@@ -1,3 +1,4 @@
 val map : f:('a -> 'b) -> 'a list -> 'b list
 (** [map ~f lst] Applies f to each element of lst and returns the resulting list.
-    This is done concurrently using threads, so f needs to be thread-safe. *)
+    This is done concurrently using threads, so f needs to be thread-safe. Also
+    the list order might not be preserved. *)

--- a/test/test_duniverse_lib.ml
+++ b/test/test_duniverse_lib.ml
@@ -6,5 +6,6 @@ let () =
       Test_duniverse.suite;
       Test_opam_show_result.suite;
       Test_dune_file.suite;
-      Test_git.suite
+      Test_git.suite;
+      Test_parallel.suite
     ]

--- a/test/test_parallel.ml
+++ b/test/test_parallel.ml
@@ -1,0 +1,22 @@
+let test_parallel =
+  let make_test ~name ~input ~f ~expected () =
+    let test_name = Printf.sprintf "map: %s" name in
+    let test_fun () =
+      let actual = Duniverse_lib.Parallel.map ~f input in
+      Alcotest.(check (slist int ( - ))) test_name expected actual
+    in
+    (test_name, `Quick, test_fun)
+  in
+  let id x = x in
+  let wait_and_sum x =
+    let rng = Random.float 0.5 in
+    Thread.delay rng;
+    x + 1
+  in
+  let input = List.init 50 id in
+  let input_plus_1 = List.map (fun x -> x + 1) input in
+  [ make_test ~name:"Identity" ~input ~f:id ~expected:input ();
+    make_test ~name:"Sleep and add 1" ~input ~f:wait_and_sum ~expected:input_plus_1 ()
+  ]
+
+let suite = ("Parallel", test_parallel)

--- a/test/test_parallel.mli
+++ b/test/test_parallel.mli
@@ -1,0 +1,1 @@
+val suite : string * unit Alcotest.test_case list


### PR DESCRIPTION
`duniverse init` and `duniverse pull` spend a great amount of time waiting for the network. Using threads allows a nice amount of parallelization, thus improving overall speed.

Some benchmarks for 105 packages.

`duniverse init`: 
* 1 thread: ∞ (> 1m)
* 20 threads: 30s
* 100 threads: 28s

`duniverse pull`:
* 1 thread: ∞ (> 1m)
* 24 threads: 10s
