### PR TITLE
Improve error reporting when resolving git refs

### DIFF
--- a/lib/git.ml
+++ b/lib/git.ml
@@ -36,9 +36,12 @@ module Ls_remote = struct
           Error `Multiple_such_refs
       | _, _ :: tl -> go acc tl
     in
-    Result.List.map ~f:parse_output_line output_lines >>= fun parsed_lines ->
-    go { maybe_packed = None; not_packed = None } parsed_lines >>= fun search_result ->
-    interpret_search_result search_result
+    match output_lines with
+    | [ "" ] -> Error `No_such_ref
+    | _ ->
+        Result.List.map ~f:parse_output_line output_lines >>= fun parsed_lines ->
+        go { maybe_packed = None; not_packed = None } parsed_lines >>= fun search_result ->
+        interpret_search_result search_result
 end
 
 module Ref = struct

--- a/test/test_git.ml
+++ b/test/test_git.ml
@@ -74,7 +74,8 @@ module Ls_remote = struct
             "004   refs/tags/abc^{}"
           ]
         ~expected:(Error `Multiple_such_refs)
-        ()
+        ();
+      make_test ~name:"Empty output" ~ref:"abc" ~lines:[ "" ] ~expected:(Error `No_such_ref) ()
     ]
 end
 


### PR DESCRIPTION
The error message when `git ls-remote` returns nothing was not very helpful as pointed out in #56.

This PR adds a preliminary check for the empty output to return an appropriate error.

The message is now:
```
duniverse: No 3.5.0 ref for git://github.com/facebook/reason.git
```
instead of:
```
duniverse: Invalid git ls-remote output line: ""
```