### PR TITLE
Improve parsing of git ls-remote

### DIFF
--- a/lib/exec.ml
+++ b/lib/exec.ml
@@ -122,6 +122,8 @@ let git_resolve ~remote ~ref =
   match Git.Ls_remote.commit_pointed_by ~ref output with
   | Ok commit -> Ok { Git.Ref.t = ref; commit }
   | Error `No_such_ref -> Rresult.R.error_msgf "No %a ref for %s" Git.Ref.pp ref remote
+  | Error `Multiple_such_refs ->
+      Rresult.R.error_msgf "A branch and a tag share the name %a on the remote %s" Git.Ref.pp ref remote
   | Error (`Msg _) as err -> err
 
 let opam_cmd ~root sub_cmd =

--- a/lib/exec.ml
+++ b/lib/exec.ml
@@ -123,7 +123,8 @@ let git_resolve ~remote ~ref =
   | Ok commit -> Ok { Git.Ref.t = ref; commit }
   | Error `No_such_ref -> Rresult.R.error_msgf "No %a ref for %s" Git.Ref.pp ref remote
   | Error `Multiple_such_refs ->
-      Rresult.R.error_msgf "A branch and a tag share the name %a on the remote %s" Git.Ref.pp ref remote
+      Rresult.R.error_msgf "A branch and a tag share the name %a on the remote %s" Git.Ref.pp ref
+        remote
   | Error (`Msg _) as err -> err
 
 let opam_cmd ~root sub_cmd =

--- a/lib/exec.ml
+++ b/lib/exec.ml
@@ -122,8 +122,6 @@ let git_resolve ~remote ~ref =
   match Git.Ls_remote.commit_pointed_by ~ref output with
   | Ok commit -> Ok { Git.Ref.t = ref; commit }
   | Error `No_such_ref -> Rresult.R.error_msgf "No %a ref for %s" Git.Ref.pp ref remote
-  | Error `Multiple_such_refs ->
-      Rresult.R.error_msgf "Multiple refs share the name %a on the remote %s" Git.Ref.pp ref remote
   | Error (`Msg _) as err -> err
 
 let opam_cmd ~root sub_cmd =

--- a/lib/git.ml
+++ b/lib/git.ml
@@ -36,17 +36,16 @@ module Ls_remote = struct
     match output_lines with
     | [ "" ] -> Error `No_such_ref
     | _ ->
-      Result.List.map ~f:parse_output_line output_lines >>= fun parsed_lines ->
-      let search prefix =
-        let result = search_ref (prefix ^ ref) parsed_lines in
-        interpret_search_result result
-      in
-      match search "refs/tags/" with
-      | Some commit -> Ok commit
-      | None ->
-        match search "refs/heads/" with
-        | Some commit -> Ok commit
-        | None -> Error `No_such_ref
+        Result.List.map ~f:parse_output_line output_lines >>= fun parsed_lines ->
+        let search prefix =
+          let result = search_ref (prefix ^ ref) parsed_lines in
+          interpret_search_result result
+        in
+        match search "refs/tags/", search "refs/heads/" with
+        | Some _, Some _ -> Error `Multiple_such_refs
+        | Some commit, None
+        | None, Some commit -> Ok commit
+        | None, None -> Error `No_such_ref
 end
 
 module Ref = struct

--- a/lib/git.ml
+++ b/lib/git.ml
@@ -23,10 +23,8 @@ module Ls_remote = struct
   let search_ref target lines =
     let target_not_packed = target ^ non_packed_suffix in
     let f acc (commit, full_ref) =
-      if String.equal full_ref target
-      then { acc with maybe_packed = Some commit }
-      else if String.equal full_ref target_not_packed
-      then { acc with not_packed = Some commit }
+      if String.equal full_ref target then { acc with maybe_packed = Some commit }
+      else if String.equal full_ref target_not_packed then { acc with not_packed = Some commit }
       else acc
     in
     List.fold_left ~f ~init:{ maybe_packed = None; not_packed = None } lines
@@ -35,17 +33,16 @@ module Ls_remote = struct
     let open Result.O in
     match output_lines with
     | [ "" ] -> Error `No_such_ref
-    | _ ->
+    | _ -> (
         Result.List.map ~f:parse_output_line output_lines >>= fun parsed_lines ->
         let search prefix =
           let result = search_ref (prefix ^ ref) parsed_lines in
           interpret_search_result result
         in
-        match search "refs/tags/", search "refs/heads/" with
+        match (search "refs/tags/", search "refs/heads/") with
         | Some _, Some _ -> Error `Multiple_such_refs
-        | Some commit, None
-        | None, Some commit -> Ok commit
-        | None, None -> Error `No_such_ref
+        | Some commit, None | None, Some commit -> Ok commit
+        | None, None -> Error `No_such_ref )
 end
 
 module Ref = struct

--- a/lib/git.mli
+++ b/lib/git.mli
@@ -6,7 +6,7 @@ module Ls_remote : sig
   val commit_pointed_by :
     ref:string ->
     string list ->
-    (string, [> `No_such_ref | `Multiple_such_refs | `Msg of string ]) result
+    (string, [> `No_such_ref | `Msg of string ]) result
   (** [commit_pointed_by ~ref ls_remote_output] parses the output from git ls-remote
       and returns the commit pointed by [ref] if it can be determined from it.
       It will work even if the repo uses packed-refs. *)

--- a/lib/git.mli
+++ b/lib/git.mli
@@ -6,7 +6,7 @@ module Ls_remote : sig
   val commit_pointed_by :
     ref:string ->
     string list ->
-    (string, [> `No_such_ref | `Msg of string ]) result
+    (string, [> `No_such_ref | `Multiple_such_refs | `Msg of string ]) result
   (** [commit_pointed_by ~ref ls_remote_output] parses the output from git ls-remote
       and returns the commit pointed by [ref] if it can be determined from it.
       It will work even if the repo uses packed-refs. *)

--- a/test/test_git.ml
+++ b/test/test_git.ml
@@ -64,7 +64,7 @@ module Ls_remote = struct
         ~expected:(Ok "0002") ();
       make_test ~name:"Points to several commits" ~ref:"abc"
         ~lines:[ "001   refs/heads/abc"; "002   refs/tags/abc" ]
-        ~expected:(Ok "002")
+        ~expected:(Error `Multiple_such_refs)
         ();
       make_test ~name:"Points to several commits (with packed-refs)" ~ref:"abc"
         ~lines:
@@ -73,7 +73,7 @@ module Ls_remote = struct
             "003   refs/tags/abc";
             "004   refs/tags/abc^{}"
           ]
-        ~expected:(Ok "004")
+        ~expected:(Error `Multiple_such_refs)
         ();
       make_test ~name:"Empty output" ~ref:"abc" ~lines:[ "" ] ~expected:(Error `No_such_ref) ();
       make_test ~name:"Not branch or tag" ~ref:"abc"

--- a/test/test_git.ml
+++ b/test/test_git.ml
@@ -64,7 +64,7 @@ module Ls_remote = struct
         ~expected:(Ok "0002") ();
       make_test ~name:"Points to several commits" ~ref:"abc"
         ~lines:[ "001   refs/heads/abc"; "002   refs/tags/abc" ]
-        ~expected:(Error `Multiple_such_refs)
+        ~expected:(Ok "002")
         ();
       make_test ~name:"Points to several commits (with packed-refs)" ~ref:"abc"
         ~lines:
@@ -73,7 +73,7 @@ module Ls_remote = struct
             "003   refs/tags/abc";
             "004   refs/tags/abc^{}"
           ]
-        ~expected:(Error `Multiple_such_refs)
+        ~expected:(Ok "004")
         ();
       make_test ~name:"Empty output" ~ref:"abc" ~lines:[ "" ] ~expected:(Error `No_such_ref) ();
       make_test ~name:"Not branch or tag" ~ref:"abc"

--- a/test/test_git.ml
+++ b/test/test_git.ml
@@ -77,16 +77,11 @@ module Ls_remote = struct
         ();
       make_test ~name:"Empty output" ~ref:"abc" ~lines:[ "" ] ~expected:(Error `No_such_ref) ();
       make_test ~name:"Not branch or tag" ~ref:"abc"
-        ~lines:
-          [ "001   refs/heads/master";
-            "002   refs/import/tags/abc";
-            "003   refs/tags/abc";
-          ]
-        ~expected:(Ok "003")
-        ();
-      make_test ~name:"Same suffix" ~ref:"abc"
-        ~lines:[ "001   refs/heads/xabc" ]
-        ~expected:(Error `No_such_ref) ();
+        ~lines:[ "001   refs/heads/master"; "002   refs/import/tags/abc"; "003   refs/tags/abc" ]
+        ~expected:(Ok "003") ();
+      make_test ~name:"Same suffix" ~ref:"abc" ~lines:[ "001   refs/heads/xabc" ]
+        ~expected:(Error `No_such_ref)
+        ()
     ]
 end
 

--- a/test/test_git.ml
+++ b/test/test_git.ml
@@ -75,7 +75,18 @@ module Ls_remote = struct
           ]
         ~expected:(Error `Multiple_such_refs)
         ();
-      make_test ~name:"Empty output" ~ref:"abc" ~lines:[ "" ] ~expected:(Error `No_such_ref) ()
+      make_test ~name:"Empty output" ~ref:"abc" ~lines:[ "" ] ~expected:(Error `No_such_ref) ();
+      make_test ~name:"Not branch or tag" ~ref:"abc"
+        ~lines:
+          [ "001   refs/heads/master";
+            "002   refs/import/tags/abc";
+            "003   refs/tags/abc";
+          ]
+        ~expected:(Ok "003")
+        ();
+      make_test ~name:"Same suffix" ~ref:"abc"
+        ~lines:[ "001   refs/heads/xabc" ]
+        ~expected:(Error `No_such_ref) ();
     ]
 end
 


### PR DESCRIPTION
See https://github.com/dune-universe/opam-overlays/pull/49#issuecomment-522923531

- Only search for `refs/heads/<ref>` (branches) and `refs/tags/<ref>` (tags) in the output of `git ls-remote`.

Remotes may have more refs but they should/can not be used, we only want branch/tags.
There should never be two refs with the same full name (`refs/...`).

- Fix a bug with the `is_suffix` logic

"abc" could match "refs/heads/xabc"

- ~~Remove the `Multiple_such_ref` error and choose tags first~~

~~If a tag and a branch have the same name, the tag is chosen. To avoid failing.~~