### PR TITLE
Path pin local packages when initializing duniverse

### DIFF
--- a/cli/init.ml
+++ b/cli/init.ml
@@ -19,7 +19,7 @@ let init_tmp_opam ~local_packages ~config:{ Duniverse.Config.remotes; pins; _ } 
   Bos.OS.Dir.tmp ".duniverse-opam-root-%s" >>= fun root ->
   Opam_cmd.init_opam ~root ~remotes () >>= fun () ->
   Exec.(iter (add_opam_dev_pin ~root) pins) >>= fun () ->
-  Exec.(iter (add_opam_local_pin ~root) local_packages) >>= fun () -> Ok root
+  Exec.(iter (add_opam_local_pin ~root ~kind:"path") local_packages) >>= fun () -> Ok root
 
 let report_stats ~packages =
   let packages_stats = Opam_cmd.packages_stats packages in

--- a/lib/exec.ml
+++ b/lib/exec.ml
@@ -178,8 +178,8 @@ let add_opam_dev_pin ~root { Opam.pin; url; tag } =
   in
   run_and_log Cmd.(opam_cmd ~root "pin" % "add" % "-yn" % (pin ^ ".dev") % targ)
 
-let add_opam_local_pin ~root package =
-  run_and_log Cmd.(opam_cmd ~root "pin" % "add" % "-yn" % (package ^ ".dev") % ".")
+let add_opam_local_pin ~root ~kind package =
+  run_and_log Cmd.(opam_cmd ~root "pin" % "add" % "-yn" % "-k" % kind % (package ^ ".dev") % ".")
 
 let run_opam_install ~yes opam_deps =
   let packages =

--- a/lib/exec.mli
+++ b/lib/exec.mli
@@ -76,9 +76,10 @@ val init_opam_and_remotes :
 val add_opam_dev_pin : root:Fpath.t -> Types.Opam.pin -> (unit, [> Rresult.R.msg ]) result
 (** [add_opam_dev_pin ~root pin] pins [pin] in the active switch using [root] as OPAMROOT. *)
 
-val add_opam_local_pin : root:Fpath.t -> string -> (unit, [> Rresult.R.msg ]) result
-(** [add_opam_local_pin ~root package] pins the package in the current working dir under
-    [package ^ ".dev"] in the active switch using [root] as OPAMROOT. *)
+val add_opam_local_pin : root:Fpath.t -> kind:string -> string -> (unit, [> Rresult.R.msg ]) result
+(** [add_opam_local_pin ~root ~kind package] pins the package in the current working dir under
+    [package ^ ".dev"] in the active switch using [root] as OPAMROOT and [kind] to determine the
+    kind of pinning ("path", "git", ...). *)
 
 val run_opam_install : yes:bool -> Duniverse.Deps.Opam.t list -> (unit, [> Rresult.R.msg ]) result
 (** [run_opam_install ~yes packages] launch an opam command to install the given packages. If yes is


### PR DESCRIPTION
A few users have been reporting issues when working with duniverse when the opam file contains uncommitted changes. This I believe it is due to the fact that opam infers the pinning method based on the content of the directory and picks `"git"`. Now we explicitly pass `path` when pinning the local packages so that `duniverse init` reflects the current state of the opam file which makes it much more convenient to work with.