### PR TITLE
Improve use of cmdliner Args

### DIFF
--- a/cli/common.ml
+++ b/cli/common.ml
@@ -1,13 +1,18 @@
 module Arg = struct
+  let named f = Cmdliner.Term.(app (const f))
+
   let fpath = Cmdliner.Arg.conv ~docv:"PATH" (Fpath.of_string, Fpath.pp)
 
   let repo =
     let doc = "Path to Git repository to store vendored code in." in
-    Cmdliner.Arg.(value & opt fpath (Fpath.v ".") & info [ "r"; "repo" ] ~docv:"TARGET_REPO" ~doc)
+    named
+      (fun x -> `Repo x)
+      Cmdliner.Arg.(
+        value & opt fpath (Fpath.v ".") & info [ "r"; "repo" ] ~docv:"TARGET_REPO" ~doc)
 
   let yes =
     let doc = "Do not prompt for confirmation and always assume yes" in
-    Cmdliner.Arg.(value & flag & info [ "y"; "yes" ] ~doc)
+    named (fun x -> `Yes x) Cmdliner.Arg.(value & flag & info [ "y"; "yes" ] ~doc)
 
   let thread_safe_reporter reporter =
     let lock = Mutex.create () in

--- a/cli/common.mli
+++ b/cli/common.mli
@@ -5,13 +5,18 @@ module Logs : sig
 end
 
 module Arg : sig
+  val named : ('a -> 'b) -> 'a Cmdliner.Term.t -> 'b Cmdliner.Term.t
+  (** Use this to wrap your arguments in a polymorphic variant constructor to avoid
+      confusion when they are later passed to your main function.
+      Example: [named (fun x -> `My_arg x] Arg.(value ...)] *)
+
   val fpath : Fpath.t Cmdliner.Arg.converter
 
-  val repo : Fpath.t Cmdliner.Term.t
+  val repo : [ `Repo of Fpath.t ] Cmdliner.Term.t
   (** CLI option to specify the root directory of the project. Used to find root packages,
       duniverse files and directories. Defaults to the current directory. *)
 
-  val yes : bool Cmdliner.Term.t
+  val yes : [ `Yes of bool ] Cmdliner.Term.t
   (** CLI flag to skip any prompt and perform actions straight away. The value of this flag
       must be passed to [Prompt.confirm]. *)
 

--- a/cli/opam_install.ml
+++ b/cli/opam_install.ml
@@ -1,8 +1,4 @@
-let run yes repo () = Duniverse_lib.Opam_cmd.install_incompatible_packages yes repo
-
-let yes =
-  let doc = "Answer yes to all yes/no questions without prompting." in
-  Cmdliner.Arg.(value & flag & info [ "yes"; "y" ] ~doc)
+let run (`Yes yes) (`Repo repo) () = Duniverse_lib.Opam_cmd.install_incompatible_packages yes repo
 
 let info =
   let open Cmdliner in
@@ -19,6 +15,7 @@ let info =
   Term.info "opam-install" ~doc ~exits ~man
 
 let term =
-  Cmdliner.Term.(term_result (const run $ yes $ Common.Arg.repo $ Common.Arg.setup_logs ()))
+  Cmdliner.Term.(
+    term_result (const run $ Common.Arg.yes $ Common.Arg.repo $ Common.Arg.setup_logs ()))
 
 let cmd = (term, info)

--- a/cli/pull.ml
+++ b/cli/pull.ml
@@ -124,7 +124,7 @@ let pull_source_dependencies ~duniverse_dir src_deps =
       report_commit_is_gone_repos commit_is_gone_repos;
       Error (`Msg "Could not pull all the source dependencies")
 
-let run yes repo () =
+let run (`Yes yes) (`Repo repo) () =
   let open Result.O in
   let duniverse_file = Fpath.(repo // Config.duniverse_file) in
   Duniverse.load ~file:duniverse_file >>= function

--- a/cli/update.ml
+++ b/cli/update.ml
@@ -20,7 +20,7 @@ let update ~total ~updated src_dep =
   debug_update ~src_dep ~new_ref;
   Ok { src_dep with ref = new_ref }
 
-let run repo () =
+let run (`Repo repo) () =
   let open Result.O in
   let duniverse_file = Fpath.(repo // Config.duniverse_file) in
   Common.Logs.app (fun l ->


### PR DESCRIPTION
Cmdliner Args are now wrapped with a constructor to avoid confusion in the `run` function arguments.

@craigfe set that up for `mdx` and I thought it would be a good idea to do the same here!