### PR TITLE
Add explicit version to .ocamlformat

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,3 @@
+version=0.9
 profile=conventional
 margin=100

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
-version=0.9
+version=0.9.1
 profile=conventional
 margin=100


### PR DESCRIPTION
I believe this is best practice although the error message isn't necessarily great it's still better than reformatting everything by mistake if you run the wrong version of ocamlformat.

It will also be helpful to benefit from https://github.com/ocaml-ci/ocaml-ci/pull/49