### PR TITLE
Move lockfiles extracting function to Repo

### DIFF
--- a/cli/common.ml
+++ b/cli/common.ml
@@ -106,23 +106,12 @@ let filter_duniverse ~to_consider (duniverse : Duniverse.t) =
             Fmt.(list ~sep string)
             unmatched)
 
-let root_lockfiles repo =
-  let open Result.O in
-  Bos.OS.Dir.contents ~dotfiles:false repo >>| fun content ->
-  List.filter
-    ~f:(fun path ->
-      let is_file =
-        match Bos.OS.File.exists path with Ok b -> b | _ -> false
-      in
-      is_file && Fpath.has_ext Config.lockfile_ext path)
-    content
-
 let find_lockfile_aux ~explicit_lockfile repo =
   let open Result.O in
   match explicit_lockfile with
   | Some file -> Ok file
   | None -> (
-      root_lockfiles repo >>= function
+      Repo.local_lockfiles repo >>= function
       | [] ->
           Rresult.R.error_msg
             "No lockfile: try running `opam monorepo lock` first"

--- a/lib/repo.ml
+++ b/lib/repo.ml
@@ -72,3 +72,14 @@ let lockfile ?local_packages:lp t =
       let name = OpamPackage.Name.to_string name in
       Ok (lockfile ~name t)
   | _ -> project_name t >>= fun name -> Ok (lockfile ~name t)
+
+let local_lockfiles repo =
+  let open Result.O in
+  Bos.OS.Dir.contents ~dotfiles:false repo >>| fun content ->
+  List.filter
+    ~f:(fun path ->
+      let is_file =
+        match Bos.OS.File.exists path with Ok b -> b | _ -> false
+      in
+      is_file && Fpath.has_ext Config.lockfile_ext path)
+    content

--- a/lib/repo.mli
+++ b/lib/repo.mli
@@ -30,3 +30,7 @@ val lockfile :
     at the root of the repo.
     One can provide [local_packages] if they were already computed are if only a subset
     of the local packages must be taken into account. *)
+
+val local_lockfiles : t -> (Fpath.t list, Rresult.R.msg) result
+(** Returns all the lockfiles located at the root of the project i.e. all
+    .opam.locked files. *)


### PR DESCRIPTION
With the fix to the lockfile path inference, we now allow users to have several lockfiles in their repositories.

This function will likely prove more and more useful so I think it makes sense to have it here.

As a follow up I'll look into eventually making the depext subcommand install depexts for all local lockfiles.