### PR TITLE
Fix permissions of pr-number action

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -18,8 +18,3 @@ jobs:
         BASE_REF: ${{ github.event.pull_request.base.ref }}
       run: |
         ! git diff --exit-code origin/$BASE_REF -- CHANGES.md
-  PR-Number-Update:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Update PR number
-        uses: tarides/pr-number-action@v1

--- a/.github/workflows/pr-number.yml
+++ b/.github/workflows/pr-number.yml
@@ -1,0 +1,8 @@
+name: PR number update
+on: [pull_request_target]
+jobs:
+  PR-Number-Update:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Update PR number
+        uses: tarides/pr-number-action@v1.1


### PR DESCRIPTION
This moves the execution to a different target which allows retrieving the write token that is required to add the suggestion to the PR even if the PR came from a fork.

I've tested this setup in https://github.com/Leonidas-from-XIV/changelog-pr-workflow-test/pull/4 with a PR spanning 2 git repos and it seems to work (and requires minor changes to the action, hence `v1.1`).