### PR TITLE
Use existing action

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,13 +7,7 @@ on:
 
 jobs:
   Changelog-Entry-Check:
+    name: Check Changelog Action
     runs-on: ubuntu-20.04
-
     steps:
-    - uses: actions/checkout@v2
-    - uses: Zomzog/changelog-checker@v1.2.0
-      with:
-        fileName: CHANGES.md
-        checkNotification: Simple
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
+      - uses: tarides/changelog-check-action@v1


### PR DESCRIPTION
Originally I had planned to make our own action, but then I thought it would be reasonable to check whether the GitHub marketplace has such a thing already, because it feels like a pretty standard thing. It turns out yes, such an action already exists and it has the settings necessary to make it work exactly the same as our current solution does.

Therefore, there is little need for our own action, unless our action would just launch this action with our desired defaults (setting the changelog file to be `CHANGES.md` and making it report via failing the build).